### PR TITLE
Improve README and SUPPORT documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,102 @@
-# Project
+# GitHub Copilot for Eclipse
 
-> This repo has been populated by an initial template to help get you started. Please
-> make sure to update the content to build a great experience for community-building.
+GitHub Copilot for Eclipse brings AI-assisted coding to the Eclipse IDE with these core capabilities:
 
-As the maintainer of this project, please make a few updates:
+- **Code completions** for in-editor suggestions from code context or natural-language comments.
+- **Next Edit Suggestions** provide context-aware suggestions for your next code edits.
+- **Agent Mode** for conversational help and more autonomous, project-aware assistance.
+- **Model Context Protocol (MCP)** integration to connect Copilot with external tools and services.
+- **Advanced Agentic Capabilities** include Custom Agents, Isolated Subagents, and Plan Agent, with more agentic capabilities coming soon.
 
-- Improving this README.MD file to provide a great experience
-- Updating SUPPORT.MD with content about this project's support experience
-- Understanding the security reporting process in SECURITY.MD
-- Remove this section from the README
 
-## Contributing
+## Getting access to GitHub Copilot
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
+Sign up for [GitHub Copilot Free](https://github.com/settings/copilot?utm_source=vscode-chat-readme&utm_medium=second&utm_campaign=2025mar-em-MSFT-signup), or request access from your enterprise admin.
 
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+To use GitHub Copilot, an active subscription is required. Learn more about business and individual plans at [github.com/features/copilot](https://github.com/features/copilot?utm_source=vscode-chat&utm_medium=readme&utm_campaign=2025mar-em-MSFT-signup).
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## Prerequisites
+
+- [Eclipse IDE](https://www.eclipse.org/downloads/)
+- An active [GitHub Copilot subscription](https://github.com/features/copilot)
+
+## Install and set up
+
+### Option 1: Eclipse Marketplace
+
+1. Open [Eclipse Marketplace](https://marketplace.eclipse.org/) and go to the [GitHub Copilot plugin page](https://marketplace.eclipse.org/content/github-copilot).
+2. Drag **Install** to your running Eclipse workspace.
+3. Restart Eclipse.
+4. Sign in to GitHub Copilot from Eclipse.
+
+### Option 2: Install from update site
+
+1. In Eclipse, open **Help → Install New Software…**
+2. Add this update site URL: `https://azuredownloads-g3ahgwb5b8bkbxhd.b01.azurefd.net/github-copilot/`
+3. Select **GitHub Copilot** and complete installation.
+4. Restart Eclipse and sign in.
+
+## Core capabilities
+
+### Code completions
+
+Inline suggestions (ghost text) appear as you type in the editor. Suggestions can range from small edits to multi-line changes.
+
+### Next Edit Suggestions
+
+Next Edit Suggestions predict your next edit location and propose the next change based on your recent edits and context.
+
+
+### Agent and Ask Mode
+
+**Ask Mode** provides conversational AI assistance for explaining code, generating code from requirements, suggesting refactors, and providing debugging guidance.
+
+**Agent Mode** works autonomously across your project context to identify and fix issues, propose implementation steps, and support larger coding tasks with iterative guidance.
+
+### Model Context Protocol (MCP)
+
+MCP support enables integrating external tools and services into Copilot workflows where configured.
+
+### Advanced Agentic Capabilities
+
+- **Custom Agents** allow users to create personalized agents with specific instructions and behaviors.
+- **Isolated Subagents** can be spawned by the main agent to handle specific tasks or contexts independently.
+- **Plan Agent** can generate multi-step plans to accomplish complex tasks, breaking them down into manageable actions.
+
+For other available features in Eclipse, see the [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=eclipse).
+
+
+## Usage tips
+
+- Keep prompts specific and include constraints
+- Request small, reviewable edits
+- Validate output with tests and static analysis
+- Treat AI output as draft code and review before committing
+
+## Privacy and responsible use
+
+We follow responsible practices in accordance with our
+[Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+
+To get the latest security fixes, please use the latest version of GitHub Copilot for Eclipse.
+
+## Data and telemetry
+
+The GitHub Copilot for Eclipse plugin collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more.
+
+
+## Security
+
+Please do not report security vulnerabilities in public issues.
+
+See [SECURITY.md](SECURITY.md) for vulnerability reporting instructions.
+
+## Support
+
+For bug reports and feature requests, use this repository’s Issues.
+
+For support guidance, see [SUPPORT.md](SUPPORT.md).
+
 
 ## Trademarks
 
@@ -31,3 +105,9 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Inline suggestions (ghost text) appear as you type in the editor. Suggestions ca
 ### Next Edit Suggestions
 
 Next Edit Suggestions predict your next edit location and propose the next change based on your recent edits and context.
+
 ### Agent and Ask Mode
 
 **Ask Mode** provides conversational AI assistance for explaining code, generating code from requirements, suggesting refactors, and providing debugging guidance.
@@ -62,7 +63,6 @@ MCP support enables integrating external tools and services into Copilot workflo
 - **Plan Agent** can generate multi-step plans to accomplish complex tasks, breaking them down into manageable actions.
 
 For other available features in Eclipse, see the [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=eclipse).
-
 
 ## Usage tips
 
@@ -82,7 +82,6 @@ To get the latest security fixes, please use the latest version of GitHub Copilo
 
 The GitHub Copilot for Eclipse plugin collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more.
 
-
 ## Security
 
 Please do not report security vulnerabilities in public issues.
@@ -94,7 +93,6 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting instructions.
 For bug reports and feature requests, use this repository’s Issues.
 
 For support guidance, see [SUPPORT.md](SUPPORT.md).
-
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Inline suggestions (ghost text) appear as you type in the editor. Suggestions ca
 ### Next Edit Suggestions
 
 Next Edit Suggestions predict your next edit location and propose the next change based on your recent edits and context.
-
-
 ### Agent and Ask Mode
 
 **Ask Mode** provides conversational AI assistance for explaining code, generating code from requirements, suggesting refactors, and providing debugging guidance.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,11 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
 ## How to file issues and get help  
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
+We'd love to get your help in making GitHub Copilot better! This project uses [GitHub Issues](https://github.com/microsoft/copilot-for-eclipse/issues) to track bugs and feature requests. Please search existing issues before filing a new one to avoid duplicates.
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+GitHub Copilot for Eclipse is under active development and maintained by Microsoft. We will do our best to respond to support, feature requests, and community questions in a timely manner.
 
 ## Microsoft Support Policy  
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+Support for this project is limited to the resources listed above.


### PR DESCRIPTION
## Summary

Improve README.md and SUPPORT.md documentation for the GitHub Copilot for Eclipse project.

## Changes

### README.md
- Rewrite with full project description, install instructions, and feature overview
- Split Code completions and Next Edit Suggestions into separate sections
- Merge Chat and Agent Mode into unified "Agent and Ask Mode" section
- Add MCP and Advanced Agentic Capabilities sections
- Add Data and telemetry, Privacy, and Usage tips sections
- Fix grammar issues (parallel structure, redundant articles, "and with" → "with")

### SUPPORT.md
- Replace "Feedback channel" with "GitHub Issues" to match the actual link target
- Add guidance to search existing issues before filing new ones