### PR TITLE
docs: Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,6 @@ MCP support enables integrating external tools and services into Copilot workflo
 
 For other available features in Eclipse, see the [Copilot feature matrix](https://docs.github.com/en/copilot/reference/copilot-feature-matrix?tool=eclipse).
 
-## Usage tips
-
-- Keep prompts specific and include constraints
-- Request small, reviewable edits
-- Validate output with tests and static analysis
-- Treat AI output as draft code and review before committing
-
 ## Privacy and responsible use
 
 We follow responsible practices in accordance with our


### PR DESCRIPTION
## Summary

This PR removes the "Usage tips" section from `README.md`.

The removed section contained generic AI usage guidance (keep prompts specific, request small edits, validate output with tests, treat AI output as draft code) that is not specific to GitHub Copilot for Eclipse and adds noise to the README.

## Changes

- **README.md**: Removed the `## Usage tips` section (7 lines)

## Screenshots

<!-- Screenshots will be added -->

## Checklist

- [x] README updated