### PR TITLE
feat(swtbot): add JSON-driven SWTBot probe harness with chat + What's New tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -154,7 +154,10 @@ Each contains `copilot-agent/` directory with Node.js binary and agent code.
 **`com.microsoft.copilot.eclipse.ui.test`** - UI bundle tests
 - JUnit tests for UI components
 - Fragment of `com.microsoft.copilot.eclipse.ui`
-- Note: SWTBot integration is planned for future enhancement
+**`com.microsoft.copilot.eclipse.swtbot.test`** - SWTBot UI probe bundle
+- JSON probe scripts executed by a generic `ProbeRunner` against a real Eclipse workbench
+- Drives the `ui-action` skill at `.github/skills/ui-action/SKILL.md`
+- Add new UI test cases by dropping JSON into `probe-scripts/` (no Java compile needed)
 
 ### Key Architecture Patterns
 
@@ -324,7 +327,7 @@ CompletableFuture.supplyAsync(() -> {
 
 **When** naming test methods → use descriptive names: `testMethodName_scenario_expectedOutcome`
 
-**When** testing UI → use SWTBot; run in dedicated test fragments; clean up resources after tests
+**When** testing UI → author a JSON probe under `com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/` and run the `ProbeRunner` via `./mvnw -pl com.microsoft.copilot.eclipse.swtbot.test -am -Dprobe.script=probe-scripts/<name>.json verify`. See `.github/skills/ui-action/SKILL.md` for the full action vocabulary, locator reference, and pass/fail judgment rules.
 
 **When** testing async operations → use appropriate timeouts
 
@@ -464,7 +467,7 @@ CompletableFuture.supplyAsync(() -> {
 
 1. Create test class in appropriate test bundle fragment
 2. Use JUnit 5 annotations: `@Test`, `@BeforeEach`, `@AfterEach`
-3. For UI tests, extend SWTBot test base classes
+3. For UI tests, add a JSON probe to `com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/` (see the `ui-action` skill). For unit-style Eclipse tests, use JUnit 5 inside `com.microsoft.copilot.eclipse.ui.test`.
 4. Mock external dependencies (LSP server, file system, etc.)
 5. Clean up resources in teardown methods
 

--- a/.github/skills/ui-action/SKILL.md
+++ b/.github/skills/ui-action/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: ui-action
+description: Write or update a SWTBot JSON probe script (e.g. from a test plan), then validate it locally by running the `ProbeRunner` Tycho test against the Copilot for Eclipse plugin. Use this whenever you need end-to-end UI validation against a real Eclipse workbench.
+---
+
+# Authoring and Validating SWTBot Probe Scripts (Eclipse)
+
+Use this skill to write or update a JSON probe script and validate it by
+invoking the `com.microsoft.copilot.eclipse.swtbot.test` Tycho bundle locally.
+Probe scripts are JSON, so no Java is compiled per test case.
+
+## Quick start
+
+1. Drop a probe at `com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/<plan-slug>-<tc-id>.json`
+   (e.g. `chat-send-receive-001.json`). Start every probe with this preamble that
+   settles the workbench and opens the Copilot Chat view:
+
+   ```json
+   [
+     { "action": "waitForIdle" },
+     { "action": "screenshot", "id": "01-startup" },
+     { "action": "showView", "idRef": "com.microsoft.copilot.eclipse.ui.chat.ChatView" },
+     { "action": "waitForIdle" },
+     { "action": "screenshot", "id": "02-chat-open" }
+   ]
+   ```
+
+2. Run it (cross-platform command; use `./mvnw` on macOS/Linux):
+
+   ```powershell
+   ./mvnw clean verify -Dprobe.script=probe-scripts/<name>.json
+   ```
+
+   Root `clean verify` is the recommended default. Tycho prefers each
+   bundle's freshly-packaged jar in `<module>/target/` and silently falls
+   back to the stale Maven cache if the jar is missing — making `setData`
+   markers and other source edits appear to be ignored.
+
+   The narrower `./mvnw -pl com.microsoft.copilot.eclipse.swtbot.test -am
+   -Dprobe.script=... verify` shortcut is **experimental**: in practice
+   it can fail dependency resolution (observed: `Missing requirement:
+   com.microsoft.copilot.eclipse.core 0.0.0`, with Tycho choosing the
+   wrong `osgi.arch` on aarch64). Use only as a follow-up, after a green
+   root `clean verify`.
+
+3. Read results under `com.microsoft.copilot.eclipse.swtbot.test/target/probe-results/`:
+
+   ```
+   results.json                  # pass/fail summary
+   workspace.log                 # sandbox Eclipse .metadata/.log
+   screenshots/
+     <id>.png                    # from `screenshot` steps
+     FAILED-stepNN-<action>.png  # auto-captured on step failure
+   ui-dumps/<id>.xml             # from `dumpUi` steps
+   ```
+
+If `-Dprobe.script` is unset the test is skipped, so ordinary `./mvnw verify`
+runs are unaffected.
+
+> **Linux headless:** prefix with `xvfb-run -a`. **macOS:** the swtbot test
+> pom carries a `swtbot-osx` profile that injects `-XstartOnFirstThread`
+> into the test JVM via the `swtbot.platformArgLine` placeholder
+> interpolated into `<argLine>`. If you ever edit
+> `com.microsoft.copilot.eclipse.swtbot.test/pom.xml`, **keep the
+> `${swtbot.platformArgLine}` token in `<argLine>`** — replacing it with a
+> plain literal silently drops the macOS arg and the workbench fails with
+> `SWTException: Invalid thread access`. **Stale cache recovery:**
+> `Remove-Item -Recurse -Force $env:USERPROFILE\.m2\repository\com\microsoft\copilot\eclipse`
+> then re-run `clean verify`.
+
+## How the runner works
+
+`ProbeRunner` is a JUnit 4 test Tycho launches under a real Eclipse workbench
+(`useUIHarness=true`, `useUIThread=false`). It:
+
+1. Loads the JSON probe pointed at by `-Dprobe.script`.
+2. Walks each step via `SWTWorkbenchBot`, wrapping every step in a uniform
+   try/catch so one failure doesn't crash the run.
+3. Writes `results.json`, screenshots (PNG — `SWTBotPreferences.SCREENSHOT_FORMAT`
+   is pinned), and widget-tree dumps.
+4. Fails the Maven build if any `failFast` step failed.
+
+Before the bot starts, the runner pre-populates configuration-scope
+preferences so Quick Start, What's New, Welcome, and "Terminal Support
+Unavailable" dialogs don't pop during a probe — probes see a clean workbench.
+
+`screenshot` and `dumpUi` capture from the **on-screen workbench shell**:
+`StepExecutor#captureWorkbenchShell` resolves the active workbench
+`Shell`'s bounds, then snapshots those screen pixels with
+`java.awt.Robot.createScreenCapture` (with SWTBot's full-display
+`bot.captureScreenshot` as a final fallback). SWT's own GC-based capture
+(`new GC(display).copyArea(...)` and `Shell#print(GC)`) returns blank
+images on macOS Cocoa for workbench shells — Robot is the workaround.
+Caveats:
+
+- **macOS:** the JVM running the tests needs **Screen Recording**
+  permission (System Settings → Privacy & Security → Screen Recording).
+  Without it Robot returns blank or wallpaper-only frames.
+- **Headless AWT:** `-Djava.awt.headless=true` makes `new Robot()` throw,
+  and the SWTBot fallback is also blank on Cocoa. Don't set it.
+- **Windows HiDPI:** `Shell#getBounds()` returns DIP coordinates; Robot
+  expects raw screen pixels. At display scaling > 100% the captured
+  region is undersized / clipped. (At 100% — typical CI runners — it's
+  a pixel-perfect match.)
+
+## Authoring rules
+
+### Drive the UI, don't reach into services
+
+Probes **must** interact with the workbench the way a user does — SWTBot
+clicks, typing, menu navigation, keyboard shortcuts, or `invokeCommand`
+against a registered Eclipse command id (the same `IHandlerService#executeCommand`
+path that menus and key bindings trigger — useful when an entry point is
+buried in a popup like the Copilot status-bar menu, which is awkward to
+drive with SWTBot). Do not add actions that reflectively invoke private
+methods, call OSGi services to flip state, or read private fields; those
+hide real UX bugs and break on every internal refactor. If a scenario needs
+a new primitive (e.g. a chat-mode dropdown picker), extend the
+action/locator vocabulary in `StepExecutor` with a UI-level primitive,
+not a service shortcut.
+
+### Tag widgets for `widgetId` locators
+
+SWTBot's blessed identification convention is
+`widget.setData("org.eclipse.swtbot.widget.key", "<stable-id>")` at widget
+construction, located from tests with the `widgetId` locator. Zero runtime
+cost, far more robust than class-name or creation-order lookup. Prefer
+`widgetId` over `widgetClass` whenever you control the widget's construction;
+use `widgetClass` only for platform / third-party widgets you can't tag.
+
+Current tags: `user-turn` (`UserTurnWidget`), `copilot-turn`
+(`CopilotTurnWidget`), `model-picker` (chat-model `DropdownButton`).
+
+### Screenshots are artifacts; assertions catch regressions
+
+`screenshot` never fails a step. Validation has two layers:
+
+- **Structural** (machine-checked): `assertExists`, `waitFor`, specific
+  locators. These failures land in `results.json` and drive the build exit
+  code — the agent judges pass/fail from here.
+- **Visual** (agent-checked): after the run, open the PNGs under
+  `screenshots/` with your vision tool and describe what you see. No
+  baseline-image comparison in JSON (cross-platform font rendering makes
+  pixel diffs flaky).
+
+Pair screenshots with assertions around every non-trivial interaction:
+
+```json
+{ "action": "screenshot", "id": "before-send" },
+{ "action": "click", "locator": { "by": "buttonWithTooltip", "tooltip": "Send" } },
+{ "action": "waitForIdle" },
+{ "action": "assertExists", "locator": { "by": "widgetId", "value": "user-turn" } },
+{ "action": "screenshot", "id": "after-send" }
+```
+
+When a locator is wrong, insert a `dumpUi` step and inspect
+`ui-dumps/*.xml` to find the real widget class / id.
+
+### Authentication prerequisite
+
+The Copilot JS agent reads its GitHub token from the host's standard Copilot
+store (`%USERPROFILE%\AppData\Local\github-copilot\apps.json` on Windows;
+`~/.config/github-copilot/apps.json` elsewhere) — the Tycho JVM inherits it.
+
+- **Signed-in host required** for any probe that exercises chat. Sign in via
+  any Copilot client (Eclipse plugin, VS Code, `gh auth login`).
+- **Probing unauthed state:** assert on the "Sign in to GitHub" button that
+  replaces the chat input; don't poll internal status managers.
+- CI-side auth bootstrap is out of scope for this skill.
+
+## Reading results & interpreting failures
+
+Maven exit code `0` **and** `results.json` `.failed == 0` → overall pass.
+Otherwise open the failed step's `message`, its `FAILED-stepNN-*.png`, the
+nearest `ui-dumps/*.xml`, **and** `workspace.log` — many "widget not found"
+failures are downstream of a Copilot LS that never started or authenticated.
+Look for `!ENTRY com.microsoft.copilot.eclipse` entries and NPEs on
+`CopilotLanguageServer.*`.
+
+| Symptom | What's wrong / fix |
+|---|---|
+| `IllegalArgumentException: Missing required field: …` | Step JSON missing a field required by that action (see action table). |
+| `AssertionError: waitFor timed out: locator …` | Widget not appearing. Add a `dumpUi` before the failing step, check class/id, or raise `timeoutSec`. |
+| `assertExists failed: … shouldExist=true` | Locator didn't match. Confirm `by` matches the widget family. |
+| `click not supported on <Type>` | Wrapper has no `click()`; use the right `by` (e.g. `button`, not `label`). |
+| Tests skipped: "No probe script specified" | Pass `-Dprobe.script=probe-scripts/<name>.json`. |
+| `model-info-label` wait times out | Usually auth; open `workspace.log`. |
+| All screenshots are blank / identical ~4KB PNGs across every step | Robot capture failed. macOS: grant Screen Recording permission to the JVM and re-run. Verify by file size — real workbench frames are 50KB+; a uniform 4KB family means the on-screen capture path didn't run or returned empty pixels. |
+| Widget-id markers missing from `dumpUi` | Stale Maven cache — run full `clean verify` (see Quick start). |
+
+Quick pass/fail check:
+
+```powershell
+Get-Content com.microsoft.copilot.eclipse.swtbot.test/target/probe-results/results.json |
+  ConvertFrom-Json | Select-Object passed, failed, durationMs
+```
+
+```bash
+jq '{passed, failed, failed_steps: [.steps[] | select(.status=="failed") | {index, action, message}]}' \
+  com.microsoft.copilot.eclipse.swtbot.test/target/probe-results/results.json
+```
+
+## Action reference
+
+Set `"failFast": false` on a step to record a failure without aborting the probe.
+
+| `action` | Required | Optional | Notes |
+|---|---|---|---|
+| `screenshot` | — | `id` | PNG of the active workbench window written to `screenshots/`. |
+| `sleep` | — | `timeoutSec` (default 1) | Plain `Thread.sleep`. |
+| `waitForIdle` | — | — | Flushes the SWT event queue. |
+| `pressKey` | `key` | `locator` | Accepts `ENTER`/`CR`, `ESC`/`ESCAPE`, `TAB`, `SPACE`, `BS`/`BACKSPACE`, `DELETE`. Without `locator`, presses on the active shell; with a `locator` targeting a text / styledText widget, sends the key directly (needed for chat input ENTER-to-send). |
+| `showView` | `idRef` (Eclipse view id) | — | Opens via `IWorkbenchPage#showView`. |
+| `closeView` | `idRef` | — | Hides the view if present. |
+| `invokeCommand` | `idRef` (command id) | — | Runs via `IHandlerService#executeCommand`. |
+| `click` | `locator` | — | Reflective `click()` on matched widget. |
+| `typeIn` | `locator`, `text` | — | Works on text / styled-text widgets. |
+| `clearElement` | `locator` | — | Sets text to empty. |
+| `waitFor` | `locator` | `timeoutSec` (default 30) | Polls until locator resolves. |
+| `waitForMethod` | `locator`, `method` | `timeoutSec` (default 30), `expectedValue` | Polls until a no-arg getter on the located widget returns non-null (and non-empty for `String`), or — if `expectedValue` is set — until `toString()` equals it. Invoked reflectively via the class hierarchy. Use for UI-exposed state not reachable via finders, e.g. `DropdownButton.getSelectedItemId()`. |
+| `assertExists` | `locator` | `shouldExist` (default true) | Asserts presence / absence. |
+| `dumpUi` | — | `id` | Writes widget hierarchy XML. |
+| `newSession` | — | — | Copilot-specific: triggers `newChatSession` command. |
+
+## Locator reference
+
+Locators are JSON objects with a `by` discriminator. SWTBot is **not
+XPath-based** — stick to this vocabulary; extend `Locator` / `StepExecutor`
+if you need a new finder.
+
+| `by` | Other fields | What it finds |
+|---|---|---|
+| `viewId` | `id` | Eclipse view by id (`bot.viewById`). |
+| `label` | `text` | First label with the given text. |
+| `button` | `text` | First button with the given text. |
+| `buttonWithTooltip` | `tooltip` | First button whose tooltip matches (use for icon-only buttons like **Send**). |
+| `text` | `index` (default 0) | Nth text field. |
+| `styledText` | — | First StyledText (editors / chat input). |
+| `tree` | `labels` (array) | Tree path under the active tree. |
+| `cssId` | `value` | Widget whose `CssConstants.CSS_ID_KEY` equals `value` (e.g. `chat-content-viewer`, `chat-action-bar`). Walks the full shell tree. |
+| `cssClass` | `value` | Widget whose `CssConstants.CSS_CLASS_NAME_KEY` contains `value` as a token. `model-info-label` is only set on a **completed** Copilot turn, so waiting on it is a reliable "response received" signal. |
+| `widgetId` | `value` | Widget tagged with `setData("org.eclipse.swtbot.widget.key", value)`. **Preferred** identifier for widgets you own. |
+| `widgetClass` | `value` | First widget whose `getClass().getSimpleName()` equals `value` (walks the full shell tree). Fallback for widgets you can't tag. |
+
+## Canonical example: send a prompt and verify a response
+
+```json
+{ "action": "clearElement", "locator": { "by": "styledText" } },
+{ "action": "typeIn",       "locator": { "by": "styledText" }, "text": "your prompt" },
+{ "action": "screenshot",   "id": "typed" },
+
+{ "action": "waitForMethod",
+  "locator": { "by": "widgetId", "value": "model-picker" },
+  "method": "getSelectedItemId",
+  "timeoutSec": 60 },
+
+{ "action": "click",        "locator": { "by": "buttonWithTooltip", "tooltip": "Send" } },
+
+{ "action": "waitFor",      "locator": { "by": "widgetId", "value": "user-turn" },
+  "timeoutSec": 30 },
+{ "action": "assertExists", "locator": { "by": "widgetId", "value": "user-turn" } },
+
+{ "action": "waitFor",      "locator": { "by": "cssClass", "value": "model-info-label" },
+  "timeoutSec": 120 },
+{ "action": "screenshot",   "id": "agent-response" },
+{ "action": "assertExists", "locator": { "by": "widgetId", "value": "copilot-turn" } }
+```
+
+Key signals:
+
+- `model-picker.getSelectedItemId()` non-null — the workbench has resolved an
+  active chat model. Sending before this NPEs in `onSendInternal` with
+  "activeModel is null" because auth + model fetch complete asynchronously.
+- `user-turn` — the user turn has rendered (Send button dispatched the prompt).
+- `model-info-label` — only appears once a Copilot turn has **completed**
+  (rendered in the turn's footer at end of streaming); the reliable "response
+  fully received" signal.
+- `copilot-turn` — the assistant turn container; good secondary assertion.
+
+Without a signed-in host the language server can't complete a turn, so
+`model-info-label` never appears and the step times out — itself a useful
+diagnostic (check `workspace.log`).
+
+## Extending the vocabulary
+
+Everything the probe understands lives in
+`com.microsoft.copilot.eclipse.swtbot.test/src/.../probe/`:
+
+- `ProbeStep.java` / `Locator.java` — JSON shape.
+- `StepExecutor.java` — action dispatch + locator resolution.
+- `ProbeRunner.java` — runner loop, reporting, screenshots.
+
+Add a case to the `switch` in `StepExecutor#execute` (or `resolve`) and the new
+action is usable from every probe.
+
+### Keep one probe focused
+
+Each JSON script represents one test case. Split unrelated behaviours into
+separate probes so a single `FAILED-step…` screenshot tells you what broke.

--- a/base.target
+++ b/base.target
@@ -16,8 +16,14 @@
 			<unit id="org.eclipse.jgit" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-				<!-- Wildwebdeveloper version 1.3.2 is the latest version that support JavaSE-17 as the execution environment -->
-				<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.2/"/>
+			<repository location="https://download.eclipse.org/technology/swtbot/releases/latest/"/>
+			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.swtbot.junit4_x" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<!-- Wildwebdeveloper version 1.3.2 is the latest version that support JavaSE-17 as the execution environment -->
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.2/"/>
 				<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/com.microsoft.copilot.eclipse.swtbot.test/.classpath
+++ b/com.microsoft.copilot.eclipse.swtbot.test/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/com.microsoft.copilot.eclipse.swtbot.test/.gitignore
+++ b/com.microsoft.copilot.eclipse.swtbot.test/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/bin/
+/screenshots/

--- a/com.microsoft.copilot.eclipse.swtbot.test/.project
+++ b/com.microsoft.copilot.eclipse.swtbot.test/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.swtbot.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.swtbot.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.microsoft.copilot.eclipse.swtbot.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/com.microsoft.copilot.eclipse.swtbot.test/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.swtbot.test/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.swtbot.test/META-INF/MANIFEST.MF
+++ b/com.microsoft.copilot.eclipse.swtbot.test/META-INF/MANIFEST.MF
@@ -1,0 +1,22 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: com.microsoft.copilot.eclipse.swtbot.test
+Bundle-SymbolicName: com.microsoft.copilot.eclipse.swtbot.test;singleton:=true
+Bundle-Version: 0.16.0.qualifier
+Bundle-Vendor: GitHub Copilot
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Automatic-Module-Name: com.microsoft.copilot.eclipse.swtbot.test
+Require-Bundle: org.eclipse.swtbot.swt.finder;bundle-version="4.1.0",
+ org.eclipse.swtbot.eclipse.finder;bundle-version="4.1.0",
+ org.eclipse.swtbot.junit4_x;bundle-version="4.1.0",
+ org.junit;bundle-version="4.13.0",
+ org.hamcrest.core;bundle-version="1.3.0",
+ org.eclipse.ui;bundle-version="3.205.0",
+ org.eclipse.ui.ide,
+ org.eclipse.core.runtime,
+ org.eclipse.core.resources,
+ org.eclipse.swt,
+ org.eclipse.jface,
+ com.google.gson,
+ com.microsoft.copilot.eclipse.core,
+ com.microsoft.copilot.eclipse.ui

--- a/com.microsoft.copilot.eclipse.swtbot.test/build.properties
+++ b/com.microsoft.copilot.eclipse.swtbot.test/build.properties
@@ -1,0 +1,6 @@
+source.. = src
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               probe-scripts/

--- a/com.microsoft.copilot.eclipse.swtbot.test/plugin.xml
+++ b/com.microsoft.copilot.eclipse.swtbot.test/plugin.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+</plugin>

--- a/com.microsoft.copilot.eclipse.swtbot.test/pom.xml
+++ b/com.microsoft.copilot.eclipse.swtbot.test/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.microsoft.copilot.eclipse</groupId>
+		<artifactId>github-copilot-for-eclipse</artifactId>
+		<version>${copilot-plugin-version}</version>
+	</parent>
+	<artifactId>com.microsoft.copilot.eclipse.swtbot.test</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<name>${base.name} :: SWTBot UI Probe Tests</name>
+
+	<properties>
+		<checkstyle.skip>true</checkstyle.skip>
+		<!-- Default to empty; the osx profile below overrides to -XstartOnFirstThread. -->
+		<swtbot.platformArgLine></swtbot.platformArgLine>
+	</properties>
+
+	<profiles>
+		<profile>
+			<id>swtbot-osx</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- SWT on macOS must be started on the main thread. -->
+				<swtbot.platformArgLine>-XstartOnFirstThread</swtbot.platformArgLine>
+			</properties>
+		</profile>
+	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- Pulls the platform-appropriate Copilot LS agent fragment into the
+							     provisioned test runtime so the language server can actually start.
+							     The feature itself carries the per-OS/arch filters, so we avoid
+							     referencing any single platform fragment here. -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>com.microsoft.copilot.eclipse.feature</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<useUIHarness>true</useUIHarness>
+					<useUIThread>false</useUIThread>
+					<includes>
+						<include>**/ProbeRunner.java</include>
+					</includes>
+					<argLine>${swtbot.platformArgLine} -Dprobe.script=${probe.script}</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/chat-send-receive-001.json
+++ b/com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/chat-send-receive-001.json
@@ -1,0 +1,49 @@
+[
+  { "action": "waitForIdle" },
+  { "action": "screenshot", "id": "01-startup" },
+
+  { "action": "showView", "idRef": "com.microsoft.copilot.eclipse.ui.chat.ChatView" },
+  { "action": "waitForIdle" },
+  { "action": "screenshot", "id": "02-chat-open" },
+
+  { "action": "assertExists",
+    "locator": { "by": "viewId", "id": "com.microsoft.copilot.eclipse.ui.chat.ChatView" } },
+
+  { "action": "waitFor",
+    "locator": { "by": "styledText" },
+    "timeoutSec": 30 },
+
+  { "action": "click", "locator": { "by": "styledText" } },
+  { "action": "clearElement", "locator": { "by": "styledText" } },
+  { "action": "typeIn", "locator": { "by": "styledText" }, "text": "hello" },
+  { "action": "screenshot", "id": "03-typed" },
+
+  { "action": "dumpUi",     "id": "03b-pre-model-poll" },
+  { "action": "screenshot", "id": "03c-pre-model-poll" },
+
+  { "action": "waitForMethod",
+    "locator": { "by": "widgetId", "value": "model-picker" },
+    "method": "getSelectedItemId",
+    "timeoutSec": 60 },
+
+  { "action": "waitFor",
+    "locator": { "by": "buttonWithTooltip", "tooltip": "Send" },
+    "timeoutSec": 30 },
+  { "action": "click", "locator": { "by": "buttonWithTooltip", "tooltip": "Send" } },
+
+  { "action": "waitFor",
+    "locator": { "by": "widgetId", "value": "user-turn" },
+    "timeoutSec": 30 },
+  { "action": "screenshot", "id": "04-user-message" },
+  { "action": "assertExists",
+    "locator": { "by": "widgetId", "value": "user-turn" } },
+
+  { "action": "waitFor",
+    "locator": { "by": "cssClass", "value": "model-info-label" },
+    "timeoutSec": 120 },
+  { "action": "screenshot", "id": "05-agent-response" },
+  { "action": "assertExists",
+    "locator": { "by": "widgetId", "value": "copilot-turn" } },
+  { "action": "assertExists",
+    "locator": { "by": "cssClass", "value": "model-info-label" } }
+]

--- a/com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/whats-new-001.json
+++ b/com.microsoft.copilot.eclipse.swtbot.test/probe-scripts/whats-new-001.json
@@ -1,0 +1,20 @@
+[
+  { "action": "waitForIdle" },
+  { "action": "screenshot", "id": "01-startup" },
+
+  { "action": "invokeCommand", "idRef": "com.microsoft.copilot.eclipse.commands.showWhatIsNew" },
+  { "action": "waitForIdle" },
+  { "action": "sleep", "timeoutSec": 2 },
+  { "action": "waitForIdle" },
+  { "action": "screenshot", "id": "02-whats-new-opened" },
+
+  { "action": "dumpUi", "id": "02b-whats-new-editor" },
+
+  { "action": "waitFor",
+    "locator": { "by": "widgetClass", "value": "Browser" },
+    "timeoutSec": 30 },
+  { "action": "assertExists",
+    "locator": { "by": "widgetClass", "value": "Browser" } },
+
+  { "action": "screenshot", "id": "03-whats-new-rendered" }
+]

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/Locator.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/Locator.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+import java.util.List;
+
+/**
+ * A widget locator expressed as a small discriminated union.
+ *
+ * <p>SWT/SWTBot does not use XPath; instead we select widgets by their SWTBot finder
+ * (label, button, tree path, etc.). The {@link #by} field selects the finder and the
+ * remaining fields carry its arguments.</p>
+ *
+ * <p>Supported {@code by} values:</p>
+ * <ul>
+ *   <li>{@code viewId} — uses {@link #id} as an Eclipse view id.</li>
+ *   <li>{@code label} — uses {@link #text} to find a label widget.</li>
+ *   <li>{@code button} — uses {@link #text} to find a button.</li>
+ *   <li>{@code buttonWithTooltip} — uses {@link #tooltip} to find a button by its tooltip text.</li>
+ *   <li>{@code widgetClass} — walks the shell tree and matches on
+ *       {@code Widget.getClass().getSimpleName()} equal to {@link #value}.
+ *       Fallback for widgets we don't own (can't tag with an SWTBot id).</li>
+ *   <li>{@code widgetId} — preferred identification: widget whose
+ *       {@code setData("org.eclipse.swtbot.widget.key", ...)} equals {@link #value}.
+ *       This is the SWTBot-blessed convention (equivalent to {@code withId}).</li>
+ *   <li>{@code text} — text field; optional {@link #index} (default 0).</li>
+ *   <li>{@code tree} — active view tree; uses {@link #labels} as node path.</li>
+ *   <li>{@code styledText} — first StyledText on the active view/editor.</li>
+ *   <li>{@code cssId} — widget whose {@code CssConstants.CSS_ID_KEY} data equals {@link #value}.</li>
+ *   <li>{@code cssClass} — widget whose {@code CssConstants.CSS_CLASS_NAME_KEY} data
+ *       contains {@link #value} (values are space-separated class lists).</li>
+ * </ul>
+ */
+public class Locator {
+  public String by;
+  public String id;
+  public String text;
+  public Integer index;
+  public List<String> labels;
+  /** Value argument for {@code cssId} / {@code cssClass} locators. */
+  public String value;
+  /** Tooltip argument for {@code buttonWithTooltip} locator. */
+  public String tooltip;
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ProbeRunner.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ProbeRunner.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.microsoft.copilot.eclipse.core.Constants;
+
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+import org.osgi.service.prefs.BackingStoreException;
+
+/**
+ * Executes a JSON probe script against the running Eclipse workbench.
+ *
+ * <p>The script path is read from the {@code probe.script} system property (relative to
+ * the bundle root, or absolute). If unset the test is skipped so ordinary {@code mvn
+ * verify} runs are unaffected.</p>
+ *
+ * <p>Output is written to {@code target/probe-results/}:</p>
+ * <ul>
+ *   <li>{@code results.json} — structured pass/fail report per step.</li>
+ *   <li>{@code screenshots/} — PNG captures; failing steps auto-produce
+ *       {@code FAILED-step&lt;N&gt;-&lt;action&gt;.png}.</li>
+ *   <li>{@code ui-dumps/} — XML widget-tree dumps from {@code dumpUi} steps.</li>
+ * </ul>
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class ProbeRunner {
+  private static final String SYSPROP = "probe.script";
+  private static final Path RESULTS_DIR = Paths.get("target", "probe-results");
+  private static final String UI_BUNDLE_ID = "com.microsoft.copilot.eclipse.ui";
+
+  private SWTWorkbenchBot bot;
+
+  @BeforeClass
+  public static void assumeScript() {
+    String v = System.getProperty(SYSPROP);
+    Assume.assumeTrue(
+        "No probe script specified via -D" + SYSPROP + "=<path>; skipping probe runner.",
+        v != null && !v.isEmpty() && !"null".equals(v) && !("${" + SYSPROP + "}").equals(v));
+    suppressNuisancePreferences();
+  }
+
+  /**
+   * Pre-populates the Copilot UI plugin's configuration-scope preferences so the
+   * workbench-startup logic in {@code CopilotUi#showHintIfNecessary} and
+   * {@code MissingTerminalDependenciesDialog#showIfNotSuppressed} skip their
+   * "first run" dialogs (Quick Start, What's New, Terminal Support Unavailable).
+   * Runs before the workbench bot exists; best-effort — any failure is logged
+   * and the probe continues.
+   */
+  private static void suppressNuisancePreferences() {
+    try {
+      IEclipsePreferences prefs = ConfigurationScope.INSTANCE.getNode(UI_BUNDLE_ID);
+      prefs.putInt(Constants.COPILOT_QUICK_START_VERSION, Constants.CURRENT_COPILOT_QUICK_START_VERSION);
+      prefs.putBoolean(Constants.AUTO_SHOW_WHAT_IS_NEW, false);
+      prefs.put(Constants.LAST_USED_COPILOT_PLUGIN_VERSION, currentUiBundleMajorMinor());
+      prefs.putBoolean(Constants.SUPPRESS_TERMINAL_DEPENDENCY_DIALOG, true);
+      prefs.flush();
+    } catch (BackingStoreException | RuntimeException e) {
+      System.err.println("[ProbeRunner] Failed to preset nuisance-dialog preferences: " + e);
+    }
+  }
+
+  private static String currentUiBundleMajorMinor() {
+    Bundle b = Platform.getBundle(UI_BUNDLE_ID);
+    if (b == null) {
+      return "0.0";
+    }
+    Version v = b.getVersion();
+    return v.getMajor() + "." + v.getMinor();
+  }
+
+  @Before
+  public void setUp() {
+    // SWTBot defaults to JPEG; pin to PNG so the .png filenames we produce are truthful.
+    SWTBotPreferences.SCREENSHOT_FORMAT = "png";
+    bot = new SWTWorkbenchBot();
+    try {
+      bot.viewByTitle("Welcome").close();
+    } catch (Exception ignored) {
+      // welcome view absent — fine
+    }
+  }
+
+  @Test
+  public void runProbe() throws Exception {
+    Path scriptPath = resolveScriptPath();
+    List<ProbeStep> steps = loadScript(scriptPath);
+
+    Path screenshotsDir = RESULTS_DIR.resolve("screenshots");
+    Path uiDumpsDir = RESULTS_DIR.resolve("ui-dumps");
+    StepExecutor executor = new StepExecutor(bot, screenshotsDir, uiDumpsDir);
+
+    ResultsWriter report = new ResultsWriter();
+    report.script = scriptPath.toString();
+
+    long t0 = System.currentTimeMillis();
+    boolean hardFailure = false;
+
+    for (int i = 0; i < steps.size(); i++) {
+      ProbeStep step = steps.get(i);
+      StepResult result = new StepResult();
+      result.index = i;
+      result.action = step.action;
+      result.id = step.id;
+      long stepStart = System.currentTimeMillis();
+      try {
+        executor.execute(step, result);
+        result.status = "passed";
+        report.passed++;
+      } catch (Throwable t) {
+        result.status = "failed";
+        result.message = t.getClass().getSimpleName() + ": " + t.getMessage();
+        executor.screenshotFailure(i, step.action, step.id);
+        report.failed++;
+        if (step.isFailFast()) {
+          hardFailure = true;
+        }
+      } finally {
+        result.durationMs = System.currentTimeMillis() - stepStart;
+        report.steps.add(result);
+      }
+      if (hardFailure) {
+        break;
+      }
+    }
+    report.durationMs = System.currentTimeMillis() - t0;
+    report.write(RESULTS_DIR.resolve("results.json"));
+    copyWorkspaceLog();
+
+    if (report.failed > 0) {
+      throw new AssertionError(
+          "Probe failed: " + report.failed + " of " + steps.size()
+              + " steps failed. See " + RESULTS_DIR.resolve("results.json"));
+    }
+  }
+
+  /**
+   * Copies the sandbox workbench's {@code .metadata/.log} next to the results so the
+   * Eclipse platform log is easy to inspect alongside screenshots and step messages.
+   * Absent or unreadable logs are ignored — the probe should never fail because of
+   * diagnostic artefact plumbing.
+   */
+  private void copyWorkspaceLog() {
+    try {
+      Path src = Platform.getLogFileLocation().toFile().toPath();
+      if (!Files.isRegularFile(src)) {
+        return;
+      }
+      Path dst = RESULTS_DIR.resolve("workspace.log");
+      Files.createDirectories(RESULTS_DIR);
+      Files.copy(src, dst, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    } catch (Exception ignored) {
+      // best effort
+    }
+  }
+
+  private Path resolveScriptPath() {
+    String raw = System.getProperty(SYSPROP);
+    Path p = Paths.get(raw);
+    if (!p.isAbsolute()) {
+      p = Paths.get("").toAbsolutePath().resolve(raw);
+    }
+    return p;
+  }
+
+  private List<ProbeStep> loadScript(Path path) throws Exception {
+    if (!Files.isRegularFile(path)) {
+      throw new IllegalArgumentException("Probe script not found: " + path);
+    }
+    try (Reader r = Files.newBufferedReader(path)) {
+      Gson gson = new Gson();
+      Type listType = new TypeToken<List<ProbeStep>>() { }.getType();
+      List<ProbeStep> steps = gson.fromJson(r, listType);
+      return steps == null ? new ArrayList<>() : steps;
+    }
+  }
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ProbeStep.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ProbeStep.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+/**
+ * A single step in a probe script. Gson-friendly POJO.
+ *
+ * <p>Fields are optional depending on {@link #action}. See {@code SKILL.md} for the
+ * canonical action vocabulary.</p>
+ */
+public class ProbeStep {
+  /** Action name (e.g. "click", "typeIn", "screenshot"). Required. */
+  public String action;
+
+  /** Optional step id; used as filename stem for screenshots and ui dumps. */
+  public String id;
+
+  /** Timeout in seconds for this step where applicable (default depends on action). */
+  public Integer timeoutSec;
+
+  /**
+   * If {@code false}, step failure is recorded but does not fail the overall probe.
+   * Default is {@code true}.
+   */
+  public Boolean failFast;
+
+  /** Free-form text payload (for typeIn, etc.). */
+  public String text;
+
+  /** Key name for pressKey (e.g. "ENTER", "ESC", "TAB"). */
+  public String key;
+
+  /** Eclipse id string (view id, command id). */
+  public String idRef;
+
+  /** Element locator. */
+  public Locator locator;
+
+  /** Whether the element should exist (for assertExists). Default true. */
+  public Boolean shouldExist;
+
+  /** No-arg method name to invoke reflectively (for waitForMethod). */
+  public String method;
+
+  /**
+   * Optional expected value for {@code waitForMethod}. If {@code null} the action
+   * polls until the return value is non-null (and non-empty for strings); otherwise
+   * it polls until the return value's {@code toString()} equals this string.
+   */
+  public String expectedValue;
+
+  public boolean isFailFast() {
+    return failFast == null ? true : failFast;
+  }
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ResultsWriter.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/ResultsWriter.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Writes the {@code results.json} report.
+ *
+ * <p>Shape is intentionally compatible with the JetBrains AgentProbe runner so agents
+ * can reuse the same parsing heuristics.</p>
+ */
+public final class ResultsWriter {
+  public String script;
+  public int passed;
+  public int failed;
+  public long durationMs;
+  public List<StepResult> steps = new ArrayList<>();
+
+  public void write(Path path) throws IOException {
+    Files.createDirectories(path.getParent());
+    Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
+    try (Writer w = Files.newBufferedWriter(path)) {
+      gson.toJson(this, w);
+    }
+  }
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/StepExecutor.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/StepExecutor.java
@@ -1,0 +1,756 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+import java.awt.AWTException;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.imageio.ImageIO;
+
+import org.eclipse.core.commands.ParameterizedCommand;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.handlers.IHandlerService;
+
+/**
+ * Executes a single {@link ProbeStep} against the running Eclipse workbench.
+ *
+ * <p>Each action method is intentionally small and throws on failure; the
+ * {@link ProbeRunner} wraps execution with try/catch and uniform reporting.</p>
+ */
+final class StepExecutor {
+  /** Matches {@code com.microsoft.copilot.eclipse.ui.swt.CssConstants.CSS_ID_KEY}. */
+  private static final String CSS_ID_KEY = "org.eclipse.e4.ui.css.id";
+  /** Matches {@code com.microsoft.copilot.eclipse.ui.swt.CssConstants.CSS_CLASS_NAME_KEY}. */
+  private static final String CSS_CLASS_NAME_KEY = "org.eclipse.e4.ui.css.CssClassName";
+  /** SWTBot's default widget-id key. Mirrors {@code SWTBotPreferences.DEFAULT_KEY}. */
+  private static final String SWTBOT_WIDGET_KEY = "org.eclipse.swtbot.widget.key";
+
+  private final SWTWorkbenchBot bot;
+  private final Path screenshotsDir;
+  private final Path uiDumpsDir;
+
+  StepExecutor(SWTWorkbenchBot bot, Path screenshotsDir, Path uiDumpsDir) {
+    this.bot = bot;
+    this.screenshotsDir = screenshotsDir;
+    this.uiDumpsDir = uiDumpsDir;
+  }
+
+  void execute(ProbeStep step, StepResult result) throws Exception {
+    String action = step.action == null ? "" : step.action;
+    switch (action) {
+      case "screenshot":
+        screenshot(step, result);
+        break;
+      case "sleep":
+        Thread.sleep(1000L * seconds(step, 1));
+        break;
+      case "waitForIdle":
+        waitForIdle();
+        break;
+      case "pressKey":
+        pressKey(step);
+        break;
+      case "showView":
+        showView(requiredRef(step));
+        break;
+      case "closeView":
+        closeView(requiredRef(step));
+        break;
+      case "invokeCommand":
+        invokeCommand(requiredRef(step));
+        break;
+      case "assertExists":
+        assertExists(step);
+        break;
+      case "waitFor":
+        waitFor(step);
+        break;
+      case "waitForMethod":
+        waitForMethod(step);
+        break;
+      case "click":
+        click(step);
+        break;
+      case "typeIn":
+        typeIn(step);
+        break;
+      case "clearElement":
+        clearElement(step);
+        break;
+      case "dumpUi":
+        dumpUi(step, result);
+        break;
+      case "newSession":
+        invokeCommand("com.microsoft.copilot.eclipse.commands.newChatSession");
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown action: " + action);
+    }
+  }
+
+  private void screenshot(ProbeStep step, StepResult result) throws IOException {
+    Files.createDirectories(screenshotsDir);
+    String base = step.id == null ? "step-" + result.index : step.id;
+    String name = safeFileSegment(base) + ".png";
+    Path out = screenshotsDir.resolve(name);
+    boolean ok = captureWorkbenchShell(out);
+    if (ok) {
+      result.screenshots.add(name);
+    }
+  }
+
+  void screenshotFailure(int index, String action, String id) {
+    try {
+      Files.createDirectories(screenshotsDir);
+      String tag = id == null ? action : action + "-" + id;
+      String name = String.format("FAILED-step%02d-%s.png", index, safeFileSegment(tag));
+      Path out = screenshotsDir.resolve(name);
+      captureWorkbenchShell(out);
+    } catch (Exception ignored) {
+      // best effort
+    }
+  }
+
+  /**
+   * Captures a PNG of just the Eclipse workbench window (active shell) rather than
+   * the whole display. Falls back to the full display if no shell is reachable.
+   */
+  private boolean captureWorkbenchShell(Path out) {
+    AtomicReference<Rectangle> shellBounds = new AtomicReference<>();
+    Display display = Display.getDefault();
+    display.syncExec(() -> {
+      Shell target = findCaptureShell(display);
+      if (target == null || target.isDisposed()) {
+        return;
+      }
+      Rectangle b = target.getBounds();
+      if (b.width > 0 && b.height > 0) {
+        shellBounds.set(b);
+      }
+    });
+    Rectangle bounds = shellBounds.get();
+    if (bounds == null) {
+      return false;
+    }
+    // Use java.awt.Robot to capture the actual on-screen pixels. SWT's own
+    // GC-based capture (`gc.copyArea(...)` from a Display GC, or `shell.print(gc)`)
+    // returns blank images on macOS Cocoa for workbench shells because SWT can't
+    // scrape the compositor and Shell#print is a no-op there. Robot works because
+    // the Tycho UI harness leaves the workbench window visible on screen.
+    try {
+      Robot robot = new Robot();
+      // Use the fully-qualified AWT Rectangle to avoid clashing with the SWT one above.
+      java.awt.Rectangle awtBounds = new java.awt.Rectangle(
+          bounds.x, bounds.y, bounds.width, bounds.height);
+      BufferedImage img = robot.createScreenCapture(awtBounds);
+      Files.createDirectories(out.getParent());
+      if (ImageIO.write(img, "png", out.toFile())) {
+        return true;
+      }
+      // ImageIO.write returns false if no PNG writer is registered (theoretical
+      // on a stock JDK). Fall through to SWTBot's full-display fallback below.
+    } catch (AWTException | IOException | SecurityException e) {
+      // Fall through to SWTBot's best-effort full-display capture.
+    }
+    return bot.captureScreenshot(out.toString());
+  }
+
+  private Shell findCaptureShell(Display display) {
+    try {
+      org.eclipse.ui.IWorkbench wb = org.eclipse.ui.PlatformUI.getWorkbench();
+      org.eclipse.ui.IWorkbenchWindow win = wb.getActiveWorkbenchWindow();
+      if (win != null) {
+        Shell s = win.getShell();
+        if (s != null && !s.isDisposed()) {
+          return s;
+        }
+      }
+    } catch (Exception ignored) {
+      // workbench not up yet
+    }
+    Shell active = display.getActiveShell();
+    if (active != null && !active.isDisposed()) {
+      return active;
+    }
+    Shell[] shells = display.getShells();
+    return shells.length > 0 ? shells[0] : null;
+  }
+
+  private void waitForIdle() {
+    Display.getDefault().syncExec(() -> { /* flush */ });
+  }
+
+  private void pressKey(ProbeStep step) {
+    String key = required(step.key, "key");
+    org.eclipse.jface.bindings.keys.KeyStroke stroke = toKeystroke(key);
+    if (step.locator != null) {
+      Object widget = resolve(step.locator);
+      if (widget instanceof SWTBotStyledText) {
+        ((SWTBotStyledText) widget).pressShortcut(stroke);
+        return;
+      }
+      if (widget instanceof SWTBotText) {
+        ((SWTBotText) widget).pressShortcut(stroke);
+        return;
+      }
+      // Fall through to shell-level press if the widget wrapper lacks pressShortcut.
+    }
+    bot.activeShell().pressShortcut(stroke);
+  }
+
+  private static org.eclipse.jface.bindings.keys.KeyStroke toKeystroke(String key) {
+    String upper = key.toUpperCase();
+    switch (upper) {
+      case "ENTER":
+      case "RETURN":
+      case "CR":
+        return Keystrokes.CR;
+      case "ESC":
+      case "ESCAPE":
+        return Keystrokes.ESC;
+      case "TAB":
+        return Keystrokes.TAB;
+      case "SPACE":
+        return Keystrokes.SPACE;
+      case "BACKSPACE":
+      case "BS":
+        return Keystrokes.BS;
+      case "DELETE":
+        return Keystrokes.DELETE;
+      default:
+        throw new IllegalArgumentException("Unsupported key: " + key);
+    }
+  }
+
+  private void showView(String viewId) {
+    IWorkbenchWindow window = waitForWorkbenchWindow();
+    AtomicReference<Exception> err = new AtomicReference<>();
+    Display.getDefault().syncExec(() -> {
+      try {
+        window.getActivePage().showView(viewId);
+      } catch (Exception e) {
+        err.set(e);
+      }
+    });
+    if (err.get() != null) {
+      throw new RuntimeException("Failed to show view " + viewId + ": " + err.get().getMessage(), err.get());
+    }
+  }
+
+  private void closeView(String viewId) {
+    IWorkbenchWindow window = waitForWorkbenchWindow();
+    Display.getDefault().syncExec(() -> {
+      IViewPart part = window.getActivePage().findView(viewId);
+      if (part != null) {
+        window.getActivePage().hideView(part);
+      }
+    });
+  }
+
+  /**
+   * Blocks until {@link PlatformUI#getWorkbench()} exposes an active workbench window.
+   * When Tycho launches with {@code useUIThread=false}, the workbench comes up on its
+   * own thread while the test thread begins running, so early steps can race ahead of
+   * workbench initialization. This polls on the UI thread for up to 30s.
+   */
+  private IWorkbenchWindow waitForWorkbenchWindow() {
+    long deadline = System.currentTimeMillis() + 30_000L;
+    AtomicReference<IWorkbenchWindow> found = new AtomicReference<>();
+    while (System.currentTimeMillis() < deadline) {
+      Display.getDefault().syncExec(() -> {
+        try {
+          IWorkbenchWindow w = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+          if (w == null) {
+            IWorkbenchWindow[] all = PlatformUI.getWorkbench().getWorkbenchWindows();
+            if (all.length > 0) {
+              w = all[0];
+            }
+          }
+          found.set(w);
+        } catch (Exception ignored) {
+          // workbench not up yet
+        }
+      });
+      if (found.get() != null) {
+        return found.get();
+      }
+      try {
+        Thread.sleep(200);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+    throw new AssertionError("Timed out waiting for active workbench window (30s).");
+  }
+
+  private void invokeCommand(String commandId) throws Exception {
+    IWorkbenchWindow window = waitForWorkbenchWindow();
+    ICommandService cmdSvc = window.getService(ICommandService.class);
+    IHandlerService handlerSvc = window.getService(IHandlerService.class);
+    ParameterizedCommand pc = new ParameterizedCommand(cmdSvc.getCommand(commandId), null);
+    AtomicReference<Exception> err = new AtomicReference<>();
+    Display.getDefault().syncExec(() -> {
+      try {
+        handlerSvc.executeCommand(pc, null);
+      } catch (Exception e) {
+        err.set(e);
+      }
+    });
+    if (err.get() != null) {
+      throw err.get();
+    }
+  }
+
+  private void waitFor(ProbeStep step) {
+    long timeoutMs = 1000L * seconds(step, 30);
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        resolve(step.locator);
+        return;
+      } catch (Exception ignored) {
+        try {
+          Thread.sleep(250);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+    }
+    throw new AssertionError("waitFor timed out: locator " + describe(step.locator));
+  }
+
+  private void assertExists(ProbeStep step) {
+    boolean should = step.shouldExist == null ? true : step.shouldExist;
+    boolean exists;
+    try {
+      resolve(step.locator);
+      exists = true;
+    } catch (Exception e) {
+      exists = false;
+    }
+    if (exists != should) {
+      throw new AssertionError(
+          "assertExists failed: locator=" + describe(step.locator) + " shouldExist=" + should);
+    }
+  }
+
+  private void click(ProbeStep step) {
+    Object widget = resolve(step.locator);
+    if (widget instanceof SWTBotStyledText) {
+      ((SWTBotStyledText) widget).setFocus();
+      return;
+    }
+    if (widget instanceof SWTBotText) {
+      ((SWTBotText) widget).setFocus();
+      return;
+    }
+    invokeClick(widget);
+  }
+
+  private void typeIn(ProbeStep step) {
+    Object widget = resolve(step.locator);
+    String payload = required(step.text, "text");
+    if (widget instanceof SWTBotText) {
+      ((SWTBotText) widget).setText(payload);
+    } else if (widget instanceof SWTBotStyledText) {
+      ((SWTBotStyledText) widget).setText(payload);
+    } else {
+      throw new IllegalArgumentException(
+          "typeIn not supported for widget type: " + widget.getClass().getSimpleName());
+    }
+  }
+
+  private void clearElement(ProbeStep step) {
+    Object widget = resolve(step.locator);
+    if (widget instanceof SWTBotText) {
+      ((SWTBotText) widget).setText("");
+    } else if (widget instanceof SWTBotStyledText) {
+      ((SWTBotStyledText) widget).setText("");
+    } else {
+      throw new IllegalArgumentException(
+          "clearElement not supported for widget type: " + widget.getClass().getSimpleName());
+    }
+  }
+
+  private void dumpUi(ProbeStep step, StepResult result) throws IOException {
+    Files.createDirectories(uiDumpsDir);
+    String base = step.id == null ? "step-" + result.index : step.id;
+    String name = safeFileSegment(base) + ".xml";
+    Path out = uiDumpsDir.resolve(name);
+    try (OutputStream os = Files.newOutputStream(out)) {
+      os.write("<ui-dump>\n".getBytes(StandardCharsets.UTF_8));
+      Display.getDefault().syncExec(() -> {
+        try {
+          for (Shell shell : Display.getDefault().getShells()) {
+            dumpWidget(os, shell, 1);
+          }
+        } catch (IOException ignored) {
+          // best effort
+        }
+      });
+      os.write("</ui-dump>\n".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private static final int MAX_DUMP_DEPTH = 20;
+
+  private void dumpWidget(OutputStream os, Widget w, int depth) throws IOException {
+    if (w == null || w.isDisposed() || depth > MAX_DUMP_DEPTH) {
+      return;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < depth; i++) {
+      sb.append("  ");
+    }
+    sb.append('<').append(w.getClass().getSimpleName());
+    try {
+      Object data = w.getData(SWTBotPreferences.DEFAULT_KEY);
+      if (data != null) {
+        sb.append(" id=\"").append(escape(data.toString())).append('"');
+      }
+    } catch (Exception ignored) {
+      // ignore
+    }
+    Widget[] children = childrenOf(w);
+    if (children.length == 0) {
+      sb.append("/>\n");
+      os.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+      return;
+    }
+    sb.append(">\n");
+    os.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+    for (Widget child : children) {
+      dumpWidget(os, child, depth + 1);
+    }
+    StringBuilder close = new StringBuilder();
+    for (int i = 0; i < depth; i++) {
+      close.append("  ");
+    }
+    close.append("</").append(w.getClass().getSimpleName()).append(">\n");
+    os.write(close.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Widget[] childrenOf(Widget w) {
+    if (w instanceof org.eclipse.swt.widgets.Composite) {
+      try {
+        return ((org.eclipse.swt.widgets.Composite) w).getChildren();
+      } catch (Exception ignored) {
+        // ignore
+      }
+    }
+    return new Widget[0];
+  }
+
+  /**
+   * Strips path separators, parent-dir tokens, and control characters from a string
+   * so it is safe to use as a single filename segment under {@code target/probe-results/}.
+   */
+  static String safeFileSegment(String s) {
+    if (s == null || s.isEmpty()) {
+      return "unnamed";
+    }
+    String cleaned = s.replace("..", "_")
+        .replace('/', '_')
+        .replace('\\', '_')
+        .replace(':', '_')
+        .replaceAll("[\\x00-\\x1F]", "_");
+    if (cleaned.isEmpty()) {
+      return "unnamed";
+    }
+    return cleaned;
+  }
+
+  private static String escape(String s) {
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+  }
+
+  private Object resolve(Locator locator) {
+    if (locator == null || locator.by == null) {
+      throw new IllegalArgumentException("Locator is required");
+    }
+    switch (locator.by) {
+      case "viewId":
+        return bot.viewById(required(locator.id, "locator.id"));
+      case "label":
+        return bot.label(required(locator.text, "locator.text"));
+      case "button":
+        return bot.button(required(locator.text, "locator.text"));
+      case "buttonWithTooltip":
+        return bot.buttonWithTooltip(required(locator.tooltip, "locator.tooltip"));
+      case "text": {
+        int idx = locator.index == null ? 0 : locator.index;
+        return bot.text(idx);
+      }
+      case "tree": {
+        SWTBotTree tree = bot.tree();
+        List<String> labels = locator.labels;
+        if (labels == null || labels.isEmpty()) {
+          throw new IllegalArgumentException("tree locator requires labels");
+        }
+        SWTBotTreeItem item = tree.getTreeItem(labels.get(0)).expand();
+        for (int i = 1; i < labels.size(); i++) {
+          item = item.getNode(labels.get(i)).expand();
+        }
+        return item;
+      }
+      case "styledText":
+        return bot.styledText();
+      case "cssId":
+        return resolveByCssMarker(CSS_ID_KEY, required(locator.value, "locator.value"), true);
+      case "cssClass":
+        return resolveByCssMarker(CSS_CLASS_NAME_KEY,
+            required(locator.value, "locator.value"), false);
+      case "widgetClass":
+        return resolveByWidgetClass(required(locator.value, "locator.value"));
+      case "widgetId":
+        return resolveByCssMarker(SWTBOT_WIDGET_KEY, required(locator.value, "locator.value"), true);
+      default:
+        throw new IllegalArgumentException("Unknown locator.by: " + locator.by);
+    }
+  }
+
+  /**
+   * Walks all shells and their descendants to find the first widget whose data under {@code key}
+   * matches {@code value}. When {@code exact} is true the data must equal value; otherwise the
+   * data is treated as a whitespace-separated list of tokens and any match is accepted.
+   */
+  private Widget resolveByCssMarker(String key, String value, boolean exact) {
+    AtomicReference<Widget> found = new AtomicReference<>();
+    int[] stats = new int[2]; // [visited, carriesAnyValueAtKey]
+    Display.getDefault().syncExec(() -> {
+      for (Shell shell : Display.getDefault().getShells()) {
+        Widget hit = searchCssMarker(shell, key, value, exact, stats);
+        if (hit != null) {
+          found.set(hit);
+          return;
+        }
+      }
+    });
+    Widget w = found.get();
+    if (w == null) {
+      throw new RuntimeException("No widget found with " + key + "=" + value
+          + " (visited=" + stats[0] + ", carriedKey=" + stats[1] + ")");
+    }
+    return w;
+  }
+
+  private Widget searchCssMarker(Widget w, String key, String value, boolean exact, int[] stats) {
+    if (w == null || w.isDisposed()) {
+      return null;
+    }
+    stats[0]++;
+    try {
+      Object data = w.getData(key);
+      if (data != null) {
+        stats[1]++;
+        String s = data.toString();
+        if (exact ? s.equals(value) : containsToken(s, value)) {
+          return w;
+        }
+      }
+    } catch (Exception ignored) {
+      // continue
+    }
+    for (Widget child : childrenOf(w)) {
+      Widget hit = searchCssMarker(child, key, value, exact, stats);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  private static boolean containsToken(String classList, String token) {
+    if (classList == null || token == null) {
+      return false;
+    }
+    for (String part : classList.trim().split("\\s+")) {
+      if (part.equals(token)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Walks all shells and returns the first widget whose simple class name (e.g.
+   * {@code UserTurnWidget}) equals {@code className}.
+   */
+  private Widget resolveByWidgetClass(String className) {
+    AtomicReference<Widget> found = new AtomicReference<>();
+    Display.getDefault().syncExec(() -> {
+      for (Shell shell : Display.getDefault().getShells()) {
+        Widget hit = searchWidgetClass(shell, className);
+        if (hit != null) {
+          found.set(hit);
+          return;
+        }
+      }
+    });
+    Widget w = found.get();
+    if (w == null) {
+      throw new RuntimeException("No widget found with simple class name=" + className);
+    }
+    return w;
+  }
+
+  private Widget searchWidgetClass(Widget w, String className) {
+    if (w == null || w.isDisposed()) {
+      return null;
+    }
+    if (className.equals(w.getClass().getSimpleName())) {
+      return w;
+    }
+    for (Widget child : childrenOf(w)) {
+      Widget hit = searchWidgetClass(child, className);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Polls a no-arg getter on the widget located by {@code step.locator} until it returns a
+   * non-null (and non-empty, for Strings) value or matches {@code step.expectedValue}.
+   *
+   * <p>Used to wait on UI-level state exposed by widgets (e.g.
+   * {@code DropdownButton.getSelectedItemId()}) without adding test-only markers into
+   * production code.</p>
+   */
+  private void waitForMethod(ProbeStep step) {
+    String methodName = required(step.method, "method");
+    long timeoutMs = 1000L * seconds(step, 30);
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    Throwable lastErr = null;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        Object widget = resolve(step.locator);
+        Object target = unwrapBotWidget(widget);
+        Object result = invokeNoArgMethod(target, methodName);
+        if (isMatch(result, step.expectedValue)) {
+          return;
+        }
+      } catch (Exception e) {
+        lastErr = e;
+      }
+      try {
+        Thread.sleep(250);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+    throw new AssertionError("waitForMethod timed out: " + methodName + " on "
+        + describe(step.locator)
+        + (step.expectedValue == null ? " (non-null)" : " (==" + step.expectedValue + ")")
+        + (lastErr == null ? "" : " — last error: " + lastErr));
+  }
+
+  private static boolean isMatch(Object result, String expected) {
+    if (expected == null) {
+      if (result == null) {
+        return false;
+      }
+      if (result instanceof String s) {
+        return !s.isEmpty();
+      }
+      return true;
+    }
+    return result != null && expected.equals(result.toString());
+  }
+
+  private static Object invokeNoArgMethod(Object target, String methodName)
+      throws ReflectiveOperationException {
+    // Walk the class hierarchy so we can reach methods declared on supertypes even if
+    // the concrete class has package-private visibility.
+    Class<?> c = target.getClass();
+    while (c != null) {
+      try {
+        java.lang.reflect.Method m = c.getDeclaredMethod(methodName);
+        m.setAccessible(true);
+        return m.invoke(target);
+      } catch (NoSuchMethodException ignored) {
+        c = c.getSuperclass();
+      }
+    }
+    throw new NoSuchMethodException(methodName + " on " + target.getClass().getName());
+  }
+
+  /**
+   * If the locator returned an SWTBot wrapper, extract the underlying SWT widget so
+   * we can invoke methods declared on the production widget class. Otherwise returns
+   * the input as-is (Shell-tree walkers already return the raw Widget).
+   */
+  private static Object unwrapBotWidget(Object widget) {
+    try {
+      java.lang.reflect.Method m = widget.getClass().getMethod("widget");
+      Object unwrapped = m.invoke(widget);
+      if (unwrapped != null) {
+        return unwrapped;
+      }
+    } catch (ReflectiveOperationException ignored) {
+      // not a SWTBot wrapper
+    }
+    return widget;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void invokeClick(Object widget) {
+    // AbstractSWTBot doesn't expose click() universally; reflectively invoke.
+    try {
+      widget.getClass().getMethod("click").invoke(widget);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("click not supported on " + widget.getClass().getSimpleName(), e);
+    }
+  }
+
+  private static String required(String value, String name) {
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("Missing required field: " + name);
+    }
+    return value;
+  }
+
+  private static String requiredRef(ProbeStep step) {
+    return required(step.idRef, "idRef");
+  }
+
+  private static int seconds(ProbeStep step, int defaultSec) {
+    return step.timeoutSec == null ? defaultSec : step.timeoutSec;
+  }
+
+  private static String describe(Locator l) {
+    if (l == null) {
+      return "null";
+    }
+    return "{by=" + l.by + ", id=" + l.id + ", text=" + l.text + ", value=" + l.value
+        + ", tooltip=" + l.tooltip + ", labels=" + l.labels + "}";
+  }
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/StepResult.java
+++ b/com.microsoft.copilot.eclipse.swtbot.test/src/com/microsoft/copilot/eclipse/swtbot/test/probe/StepResult.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ *******************************************************************************/
+package com.microsoft.copilot.eclipse.swtbot.test.probe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Accumulates step results and serializes the final report.
+ */
+public class StepResult {
+  public int index;
+  public String action;
+  public String id;
+  public String status;
+  public String message;
+  public long durationMs;
+  public List<String> screenshots = new ArrayList<>();
+}

--- a/com.microsoft.copilot.eclipse.swtbot.test/test-plans/chat-send-receive/chat-send-receive.md
+++ b/com.microsoft.copilot.eclipse.swtbot.test/test-plans/chat-send-receive/chat-send-receive.md
@@ -1,0 +1,122 @@
+# Chat: Send a Prompt and Receive a Response
+
+## Overview
+Tests the core "send a chat prompt and render the completed response" flow in
+the GitHub Copilot Chat view. This is the single most load-bearing interaction
+for the Copilot for Eclipse plugin: the view must open, its input must accept
+text, the chat model must be resolved, the **Send** button must dispatch the
+prompt as a user turn, and the language server must stream back a Copilot turn
+that completes end-to-end.
+
+The observable signals (user-turn rendered, `model-info-label` appearing on a
+completed Copilot turn) are UI-level outputs of the full stack: workbench view
+lifecycle → chat UI → model picker → LSP request/response → streaming
+renderer. A failure anywhere in that pipeline breaks the test.
+
+Entry points exercised:
+- **Window → Show View → Copilot Chat** (equivalent to the probe's
+  `showView` of view id `com.microsoft.copilot.eclipse.ui.chat.ChatView`).
+
+Not exercised in TC-001 (separate scenarios):
+- The chat-mode dropdown (Ask / Edit / Agent).
+- The model picker's explicit model selection — the probe trusts whatever
+  the picker resolves to as its default.
+- Attachment / context management.
+- Cancelling an in-flight response.
+
+---
+
+## Prerequisites
+
+- Eclipse IDE with the GitHub Copilot for Eclipse plugin installed and
+  activated.
+- **A signed-in Copilot account on the host machine.** The Copilot JS agent
+  reads its GitHub token from the OS-standard Copilot store
+  (`~/.config/github-copilot/apps.json` on macOS/Linux,
+  `%USERPROFILE%\AppData\Local\github-copilot\apps.json` on Windows). Sign in
+  via any Copilot client (Eclipse plugin, VS Code, or `gh auth login`) before
+  running the probe. Without auth the language server cannot complete a turn
+  and the `model-info-label` wait will time out.
+- Network access to `api.githubcopilot.com` (and the GitHub auth host if a
+  token refresh is needed).
+- No modal dialogs queued on workbench startup. The probe runner
+  pre-populates preferences to suppress Quick Start, What's New, Welcome, and
+  "Terminal Support Unavailable" pop-ups; authoring additional tests on top
+  of this scenario should keep that contract.
+
+---
+
+## 1. Happy-path send and receive
+
+### TC-001: Send "hello" and verify a Copilot turn completes
+
+**Type:** `Happy Path`
+**Priority:** `P0`
+
+#### Preconditions
+- The Eclipse workbench is open.
+- The user is signed in to Copilot (see Prerequisites).
+- No previous chat conversation is open in the Chat view (a fresh probe
+  sandbox satisfies this automatically; if running manually, start a new
+  session).
+
+#### Steps
+1. Wait for the workbench to settle (`waitForIdle`).
+2. Open the **Copilot Chat** view (`Window → Show View → Other… → Copilot →
+   Copilot Chat`, or use the probe's `showView` of
+   `com.microsoft.copilot.eclipse.ui.chat.ChatView`).
+3. Verify the Chat view is visible and its input area has rendered (the
+   `StyledText` chat input is present and editable).
+4. Click into the chat input to focus it.
+5. Clear any existing text and type the prompt `hello`.
+6. Wait for the model picker to resolve an active model — i.e. the picker
+   tagged `widget.setData("org.eclipse.swtbot.widget.key", "model-picker")`
+   reports a non-null `getSelectedItemId()`. This is the signal that auth
+   + the asynchronous `listModels` response from the language server have
+   both completed. Sending before this point produces an `activeModel is
+   null` NPE in the onSend path — that's a separate regression to guard
+   against, not the happy path tested here.
+7. Locate and click the **Send** button (icon-only button with tooltip
+   `Send`).
+8. Wait for a user turn to render in the chat viewer (a widget tagged
+   `user-turn`, i.e. a `UserTurnWidget` instance). This proves the Send
+   button dispatched the prompt into the conversation state and the view
+   re-rendered.
+9. Wait up to ~120 s for a Copilot turn to complete. The reliable signal is
+   a widget with CSS class `model-info-label`, which is only attached to a
+   Copilot turn's footer **after** streaming finishes. (A `copilot-turn`
+   widget appears earlier, while streaming is in progress; asserting on it
+   alone doesn't prove the turn completed successfully.)
+10. Verify a `copilot-turn` widget exists and at least one
+    `model-info-label` is present in the view hierarchy.
+
+#### Expected Result
+- The Chat view opens and accepts keyboard input.
+- The Send button dispatches the prompt; a user turn renders with the exact
+  text submitted.
+- Within ~120 seconds, a Copilot turn appears and completes streaming — its
+  footer renders a `model-info-label` showing which model served the
+  response.
+- No error dialog is shown. `workspace.log` contains no
+  `!ENTRY com.microsoft.copilot.eclipse` entries at `ERROR` level and no
+  NPEs originating in `CopilotLanguageServer.*` / the Chat UI.
+
+#### 📸 Key Screenshots
+- [ ] **Chat view open** — empty conversation, input focused.
+- [ ] **Prompt typed** — input shows `hello`, Send button visible.
+- [ ] **User turn rendered** — the user turn appears in the transcript
+  immediately after Send.
+- [ ] **Agent response completed** — the Copilot turn is present and its
+  `model-info-label` footer is visible (streaming is done).
+
+#### Notes on failure modes
+- `model-picker.getSelectedItemId()` never becomes non-null → auth or LS
+  startup failure. Check `workspace.log` for LS launch errors and
+  `~/.config/github-copilot/apps.json` for a valid token.
+- User turn renders but `model-info-label` never appears → LS connected but
+  the turn didn't complete (rate limit, network, server-side error, or the
+  streaming renderer getting stuck). Inspect `workspace.log` for the JSON-RPC
+  stream and LSP4E warnings.
+- Widget-id locators (`model-picker`, `user-turn`, `copilot-turn`) don't
+  resolve → stale Tycho cache for the UI bundle; re-run root `clean verify`
+  to rebuild `setData` markers (see `.github/skills/ui-action/SKILL.md`).

--- a/com.microsoft.copilot.eclipse.swtbot.test/test-plans/whats-new/whats-new.md
+++ b/com.microsoft.copilot.eclipse.swtbot.test/test-plans/whats-new/whats-new.md
@@ -1,0 +1,75 @@
+# What's New Page
+
+## Overview
+Tests the "What's New" page feature of the GitHub Copilot for Eclipse plugin. The
+page renders the contents of the bundled `intro/whatsnew/WHATISNEW.md` release
+notes as HTML in an Eclipse editor, so users can see the latest features shipped
+with the plugin.
+
+Entry points:
+- Copilot status-bar icon → **What's New** menu item.
+- (Optional, not exercised in TC-001) Eclipse Welcome page → "What's New" quick link.
+
+---
+
+## Prerequisites
+
+- Eclipse IDE with the GitHub Copilot for Eclipse plugin installed and activated.
+- The plugin bundle ships `intro/whatsnew/WHATISNEW.md` (the source of the
+  rendered page). The top-most level-1 release section in that file is the
+  "latest feature" referenced below.
+- A user signed in to GitHub Copilot is **not** required to open the page, but
+  signing in first keeps the environment consistent with normal usage.
+- No previously opened `WHATISNEW.html` editor tab is currently visible (close
+  it if present to guarantee a clean observation of the open action).
+
+---
+
+## 1. Open What's New
+
+### TC-001: Open What's New and verify latest feature is shown
+
+**Type:** `Happy Path`
+**Priority:** `P1`
+
+#### Preconditions
+- The Eclipse workbench is open with at least one project in the workspace.
+- Any previously opened `WHATISNEW.html` / `WHATISNEW.md` editor tab is closed.
+- The Copilot status-bar icon is visible in the Eclipse status bar.
+
+#### Steps
+1. Click the **GitHub Copilot** icon in the Eclipse status bar to open the
+   Copilot status-bar menu.
+2. In the menu, click **What's New**.
+3. Wait for a new editor tab to open in the workbench.
+4. Inspect the opened editor:
+   1. Verify the editor tab title corresponds to the generated HTML file
+      (e.g. `WHATISNEW.html`) rendered via the internal browser editor
+      (`org.eclipse.ui.browser.editor`). A fallback to the default text editor
+      showing `WHATISNEW.md` is also acceptable if the browser editor is not
+      available on the platform.
+   2. Verify the page body renders the release notes as formatted HTML
+      (headings, bullet lists, and images are visible — not raw Markdown
+      syntax).
+5. Locate the top-most level-1 release section in the page (the first
+   `# GitHub Copilot <version> Release Notes` heading).
+6. Verify that this top-most section, and the first feature sub-heading beneath
+   it, match the top of the bundled `intro/whatsnew/WHATISNEW.md` file shipped
+   with the installed plugin build. At the time of writing, the expected
+   latest entry is:
+   - Release heading: `GitHub Copilot 0.16.0 Release Notes`
+   - First feature: `Tool Calling in Ask Mode`
+
+#### Expected Result
+- Clicking **What's New** from the Copilot status-bar menu opens an editor tab
+  that renders the plugin's release notes.
+- The latest release section from the bundled `WHATISNEW.md` appears at the top
+  of the page, and its first feature sub-heading is visible without scrolling
+  past any older release notes.
+- No error dialog is shown and no error is logged by
+  `com.microsoft.copilot.eclipse.core` during the action.
+
+#### 📸 Key Screenshots
+- [ ] **Status-bar menu** — Copilot status-bar menu showing the "What's New" entry.
+- [ ] **Rendered What's New page** — The opened editor with the latest release
+  heading and first feature sub-heading visible at the top.

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CopilotTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CopilotTurnWidget.java
@@ -29,6 +29,7 @@ public class CopilotTurnWidget extends BaseTurnWidget {
    */
   public CopilotTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId) {
     super(parent, style, serviceManager, turnId, true, null);
+    setData("org.eclipse.swtbot.widget.key", "copilot-turn");
   }
 
   @Override

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/UserTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/UserTurnWidget.java
@@ -34,6 +34,7 @@ public class UserTurnWidget extends BaseTurnWidget {
    */
   public UserTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId) {
     super(parent, style, serviceManager, turnId, false, null);
+    setData("org.eclipse.swtbot.widget.key", "user-turn");
   }
 
   @Override

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
@@ -412,6 +412,7 @@ public class ModelService extends ChatBaseService {
     // Add the selection listener ONCE here
     picker.setSelectionListener(this::setActiveModel);
     picker.setAccessibilityName("model picker");
+    picker.setData("org.eclipse.swtbot.widget.key", "model-picker");
 
     ensureRealm(() -> {
       ISideEffect modelsSideEffect = ISideEffect.create(() -> {

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 		<!-- modules for tests -->
 		<module>com.microsoft.copilot.eclipse.core.test</module>
 		<module>com.microsoft.copilot.eclipse.ui.test</module>
+		<module>com.microsoft.copilot.eclipse.swtbot.test</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
Introduce a new `com.microsoft.copilot.eclipse.swtbot.test` Tycho bundle that lets us write end-to-end UI tests against the Copilot for Eclipse plugin as JSON probe scripts, with no per-test Java compilation.

Bundle / runner
- New `eclipse-test-plugin` module wired into the parent POM with the Copilot feature pulled into its target platform via `target-platform-configuration` extra requirements (so the platform- appropriate Copilot LS agent fragment is provisioned automatically).
- `ProbeRunner` (JUnit 4, Tycho `useUIHarness=true`, `useUIThread=false`) loads the JSON pointed at by `-Dprobe.script`, walks each step via `SWTWorkbenchBot`, and writes `target/probe-results/{results.json, workspace.log, screenshots/, ui-dumps/}`. Configuration-scope prefs for Quick Start / What's New / Welcome / "Terminal Support Unavailable" are pre-populated so probes see a clean workbench. Skipped when `-Dprobe.script` is unset, so regular `./mvnw verify` remains unaffected.
- `StepExecutor` implements the action vocabulary (`screenshot`, `sleep`, `waitForIdle`, `pressKey`, `showView`/`closeView`, `invokeCommand`, `click`, `typeIn`, `clearElement`, `waitFor`, `waitForMethod`, `assertExists`, `dumpUi`, `newSession`) and the locator vocabulary (`viewId`, `label`, `button`, `buttonWithTooltip`, `text`, `styledText`, `tree`, `cssId`, `cssClass`, `widgetId`, `widgetClass`). Screenshots are captured with `java.awt.Robot` against the workbench shell's on-screen bounds — SWT's own GC-based capture (`new GC(display).copyArea(...)` and `Shell#print(GC)`) returns blank PNGs on macOS Cocoa for workbench shells; SWTBot's full-display capture remains as a fallback. `ImageIO.write` return value is checked so a missing PNG writer falls through cleanly.

macOS test JVM args
- The bundle's tycho-surefire `<argLine>` interpolates a `swtbot.platformArgLine` placeholder; a `swtbot-osx` profile (auto-activated on `<os family="mac">`) sets it to `-XstartOnFirstThread`. This matters because the explicit `<argLine>` was clobbering Tycho's normal macOS auto-injection, causing `SWTException: Invalid thread access` in the Cocoa main thread.

Probes
- `probe-scripts/chat-send-receive-001.json` — open Copilot Chat, type a prompt, wait for the model picker to resolve a model (`waitForMethod` on `model-picker.getSelectedItemId`), click Send, assert the user turn renders, then wait for the Copilot turn to complete (signalled by `model-info-label`).
- `probe-scripts/whats-new-001.json` — invoke `com.microsoft.copilot.eclipse.commands.showWhatIsNew` (the same handler the status-bar menu's What's New entry binds to) and assert the internal browser editor (`Browser` widget) renders the bundled `WHATISNEW.md` as HTML.

Widget tagging in production code
- `UserTurnWidget`, `CopilotTurnWidget`, and the Chat view's model `DropdownButton` now `setData("org.eclipse.swtbot.widget.key", …)` with stable ids (`user-turn`, `copilot-turn`, `model-picker`) so probes can locate them via the `widgetId` locator instead of brittle class-name / creation-order lookup. Zero runtime cost.

Test plans
- `test-plans/whats-new/whats-new.md` — TC-001 happy-path opening the What's New page from the status-bar menu and validating the latest release section.
- `test-plans/chat-send-receive/chat-send-receive.md` — TC-001 P0 happy-path send-and-receive with prerequisite (signed-in host), expected results, screenshot checklist, and a failure-mode glossary tying common `workspace.log` symptoms back to auth / LS / stale-cache causes.

Skill + instructions
- `.github/skills/ui-action/SKILL.md` — full skill documenting the Quick start (`./mvnw clean verify -Dprobe.script=…`), how the runner works (including the Robot-based screenshot mechanism and its caveats: macOS Screen Recording permission, headless AWT, Windows HiDPI bounds aren't pre-scaled), authoring rules (drive the UI; `invokeCommand` against registered command ids is allowed; tag widgets for `widgetId`), the action and locator references, a canonical send-a-prompt example, and a troubleshooting table.
- `.github/copilot-instructions.md` — point UI-test guidance at the new skill / probe-script workflow.

Misc
- `base.target` bumped to include SWTBot 4.2.x feature units.