### PR TITLE
feat: implement rate limit warning banner and associated parameters

### DIFF
--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/events/CopilotEventConstants.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/events/CopilotEventConstants.java
@@ -155,4 +155,9 @@ public class CopilotEventConstants {
    * Event when NES suggestion is rejected.
    */
   public static final String TOPIC_NES_REJECT_SUGGESTION = TOPIC_NES + "REJECT_SUGGESTION";
+
+  /**
+   * Event when a rate limit warning is received from the language server.
+   */
+  public static final String TOPIC_RATE_LIMIT_WARNING = TOPIC_CHAT + "RATE_LIMIT_WARNING";
 }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageClient.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageClient.java
@@ -54,6 +54,7 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.InvokeClientToolParams;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.LanguageModelToolResult;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.LanguageModelToolResult.ToolInvocationStatus;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.OnChangeMcpServerToolsParams;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.RateLimitWarningParams;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ReadFileResult;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.codingagent.CodingAgentMessageRequestParams;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.codingagent.CodingAgentMessageResult;
@@ -239,6 +240,16 @@ public class CopilotLanguageClient extends LanguageClientImpl {
   public void mcpRuntimeLogs(McpRuntimeLog mcpRuntimeLog) {
     if (eventBroker != null) {
       eventBroker.post(CopilotEventConstants.TOPIC_CHAT_MCP_RUNTIME_LOG, mcpRuntimeLog);
+    }
+  }
+
+  /**
+   * Notify when rate limit usage warning is received from the language server.
+   */
+  @JsonNotification("$/copilot/rateLimitWarning")
+  public void onRateLimitWarning(RateLimitWarningParams params) {
+    if (eventBroker != null) {
+      eventBroker.post(CopilotEventConstants.TOPIC_RATE_LIMIT_WARNING, params);
     }
   }
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/RateLimitWarningParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/RateLimitWarningParams.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.copilot.eclipse.core.lsp.protocol;
+
+/**
+ * Parameters for the "$/copilot/rateLimitWarning" notification.
+ * Sent by the language server when usage rate limits are approaching thresholds.
+ *
+ * @param type the rate limit type ("weekly" or "session")
+ * @param rateLimit the rate limit details
+ * @param message the human-readable warning message
+ */
+public record RateLimitWarningParams(String type, RateLimit rateLimit, String message) {
+
+  /**
+   * Rate limit details including entitlement, remaining percentage, and reset date.
+   *
+   * @param entitlement the total entitlement
+   * @param percentRemaining the percentage of quota remaining
+   * @param resetDate the date when the rate limit resets
+   */
+  public record RateLimit(int entitlement, double percentRemaining, String resetDate) {
+  }
+}

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/UiConstants.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/UiConstants.java
@@ -40,4 +40,5 @@ public class UiConstants {
   public static final String GITHUB_COPILOT_CODING_AGENT_SLUG = "github-copilot-coding-agent";
   public static final String GITHUB_COPILOT_CODING_AGENT_LEARN_MORE_URL = "https://aka.ms/learn-copilot-coding-agent";
   public static final String TERMINAL_DEPENDENCY_GUIDE_URL = "https://aka.ms/terminal-dependency-guide";
+  public static final String COPILOT_RATE_LIMIT_INFO_URL = "https://aka.ms/github-copilot-rate-limit-error";
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
@@ -117,6 +117,7 @@ public class ActionBar extends Composite implements NewConversationListener {
   private Image autoBreakpointImage;
   private Image autoBreakpointDisabledImage;
   private ContextSizeDonut contextSizeDonut;
+  private StaticBanner staticBanner;
 
   private ChatServiceManager chatServiceManager;
   IEventBroker eventBroker;
@@ -700,6 +701,7 @@ public class ActionBar extends Composite implements NewConversationListener {
   @Override
   public void onNewConversation() {
     resetSendButton();
+    disposeStaticBanner();
   }
 
   /**
@@ -942,6 +944,43 @@ public class ActionBar extends Composite implements NewConversationListener {
       return result;
     }
     return result;
+  }
+
+  /**
+   * Show the static banner above the bordered action bar area.
+   *
+   * @param message the message to display
+   */
+  public void createStaticBanner(String message) {
+    if (isDisposed()) {
+      return;
+    }
+    if (this.staticBanner != null && !this.staticBanner.isDisposed()) {
+      this.staticBanner.dispose();
+    }
+
+    this.staticBanner = new StaticBanner(this, SWT.NONE, message, Messages.chat_rateLimitBanner_getMoreInfo,
+        UiConstants.COPILOT_RATE_LIMIT_INFO_URL, Messages.chat_rateLimitBanner_closeTooltip);
+    // Position the banner above the first child (the bordered action bar composite)
+    if (getChildren().length > 0) {
+      this.staticBanner.moveAbove(getChildren()[0]);
+    }
+    this.staticBanner.show();
+    requestLayout();
+  }
+
+  /**
+   * Dispose the current static banner, if present.
+   */
+  public void disposeStaticBanner() {
+    if (isDisposed()) {
+      return;
+    }
+    if (this.staticBanner != null && !this.staticBanner.isDisposed()) {
+      this.staticBanner.dispose();
+    }
+    this.staticBanner = null;
+    requestLayout();
   }
 
   private void refreshLayout() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
@@ -36,7 +35,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.IContextActivation;
 import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.part.ViewPart;
-import org.osgi.framework.Bundle;
 import org.osgi.service.event.EventHandler;
 
 import com.microsoft.copilot.eclipse.core.Constants;
@@ -59,6 +57,7 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatTurnResult;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ContextSizeInfo;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotModel;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotStatusResult;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.RateLimitWarningParams;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.TodoItem;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.codingagent.CodingAgentMessageRequestParams;
@@ -134,6 +133,7 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
   private EventHandler conversationTitleUpdatedHandler;
   private EventHandler codingAgentMessageHandler;
   private EventHandler autoBreakpointToggleHandler;
+  private EventHandler rateLimitWarningHandler;
 
   // Context activation for chat view keyboard shortcuts
   private static final String CHAT_VIEW_CONTEXT = "com.microsoft.copilot.eclipse.chatViewContext";
@@ -243,6 +243,10 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
       clearCurrentConversation();
 
+      if (actionBar != null && !actionBar.isDisposed()) {
+        actionBar.disposeStaticBanner();
+      }
+
       if (conversation == null) {
         // Handle "New Chat" selection.
         hideChatHistory();
@@ -341,6 +345,18 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
     };
     this.eventBroker.subscribe(CopilotEventConstants.TOPIC_CHAT_AUTO_BREAKPOINT_TOGGLE,
         this.autoBreakpointToggleHandler);
+
+    this.rateLimitWarningHandler = event -> {
+      Object data = event.getProperty(IEventBroker.DATA);
+      if (data instanceof RateLimitWarningParams params) {
+        SwtUtils.invokeOnDisplayThreadAsync(() -> {
+          if (actionBar != null && !actionBar.isDisposed()) {
+            actionBar.createStaticBanner(params.message());
+          }
+        }, parent);
+      }
+    };
+    this.eventBroker.subscribe(CopilotEventConstants.TOPIC_RATE_LIMIT_WARNING, this.rateLimitWarningHandler);
 
     // Register part listener to activate/deactivate chat view context for keyboard shortcuts
     registerPartListener();
@@ -1289,6 +1305,10 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
       if (autoBreakpointToggleHandler != null) {
         this.eventBroker.unsubscribe(this.autoBreakpointToggleHandler);
         autoBreakpointToggleHandler = null;
+      }
+      if (rateLimitWarningHandler != null) {
+        this.eventBroker.unsubscribe(this.rateLimitWarningHandler);
+        rateLimitWarningHandler = null;
       }
     }
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/StaticBanner.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/StaticBanner.java
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.copilot.eclipse.ui.chat;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+
+import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
+
+/**
+ * A reusable banner widget that displays an informational message with an inline link and a close button. Shows an info
+ * icon, the provided message with an appended link, and a dismiss (×) button.
+ *
+ * <p>
+ * Usage example:
+ * 
+ * <pre>
+ * var banner = new StaticBanner(parent, SWT.NONE, "You've used 90% of your rate limit.", "Get more info",
+ *     "https://example.com", "Dismiss");
+ * banner.show();
+ * </pre>
+ */
+public class StaticBanner extends Composite {
+  private Link messageLink;
+
+  /**
+   * Create a static informational banner.
+   *
+   * @param parent the parent composite
+   * @param style the SWT style
+   * @param message the informational message to display
+   * @param linkText the text for the inline link (e.g. "Get more info")
+   * @param linkUrl the URL to open when the link is clicked
+   * @param closeTooltip the tooltip for the close button
+   */
+  public StaticBanner(Composite parent, int style, String message, String linkText, String linkUrl,
+      String closeTooltip) {
+    super(parent, style | SWT.BORDER);
+
+    GridLayout layout = new GridLayout(3, false);
+    layout.marginWidth = 10;
+    layout.marginHeight = 8;
+    layout.horizontalSpacing = 6;
+    setLayout(layout);
+    setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
+
+    // Info icon
+    Label iconLabel = new Label(this, SWT.NONE);
+    Image infoImage = PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK);
+    iconLabel.setImage(infoImage);
+    iconLabel.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false));
+
+    // Message + inline link
+    this.messageLink = new Link(this, SWT.WRAP);
+    this.messageLink.setText(buildMessageText(message, linkText, linkUrl));
+    this.messageLink.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+    this.messageLink.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        if (StringUtils.isNotBlank(linkUrl)) {
+          UiUtils.openLink(linkUrl);
+        }
+      }
+    });
+
+    // Close button
+    Label closeButton = new Label(this, SWT.NONE);
+    Image closeImage = PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_ELCL_REMOVE);
+    closeButton.setImage(closeImage);
+    closeButton.setLayoutData(new GridData(SWT.RIGHT, SWT.TOP, false, false));
+    closeButton.setToolTipText(closeTooltip);
+    closeButton.setCursor(getDisplay().getSystemCursor(SWT.CURSOR_HAND));
+    closeButton.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseUp(MouseEvent e) {
+        disposeBanner();
+      }
+    });
+
+    setVisible(false);
+    GridData gd = (GridData) getLayoutData();
+    gd.exclude = true;
+  }
+
+  /**
+   * Show the banner.
+   */
+  public void show() {
+    if (isDisposed()) {
+      return;
+    }
+    setVisible(true);
+    GridData gd = (GridData) getLayoutData();
+    gd.exclude = false;
+    getParent().requestLayout();
+  }
+
+  /**
+   * Hide the banner.
+   */
+  public void hide() {
+    if (isDisposed()) {
+      return;
+    }
+    setVisible(false);
+    GridData gd = (GridData) getLayoutData();
+    gd.exclude = true;
+    getParent().requestLayout();
+  }
+
+  private void disposeBanner() {
+    if (isDisposed()) {
+      return;
+    }
+    Composite parent = getParent();
+    dispose();
+    if (parent != null && !parent.isDisposed()) {
+      parent.requestLayout();
+    }
+  }
+
+  private static String buildMessageText(String message, String linkText, String linkUrl) {
+    String safeMessage = escapeForLink(message);
+    if (StringUtils.isBlank(linkText) || StringUtils.isBlank(linkUrl)) {
+      return safeMessage;
+    }
+    return NLS.bind(com.microsoft.copilot.eclipse.ui.i18n.Messages.chat_staticBanner_messageWithLink, safeMessage,
+        escapeForLink(linkText));
+  }
+
+  private static String escapeForLink(String text) {
+    if (text == null) {
+      return StringUtils.EMPTY;
+    }
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+  }
+}

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/StaticBanner.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/StaticBanner.java
@@ -25,11 +25,9 @@ import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
  * A reusable banner widget that displays an informational message with an inline link and a close button. Shows an info
  * icon, the provided message with an appended link, and a dismiss (×) button.
  *
- * <p>
- * Usage example:
- * 
- * <pre>
- * var banner = new StaticBanner(parent, SWT.NONE, "You've used 90% of your rate limit.", "Get more info",
+ * <p>Usage example:
+ *
+ * <pre>var banner = new StaticBanner(parent, SWT.NONE, "You've used 90% of your rate limit.", "Get more info",
  *     "https://example.com", "Dismiss");
  * banner.show();
  * </pre>
@@ -106,19 +104,6 @@ public class StaticBanner extends Composite {
     setVisible(true);
     GridData gd = (GridData) getLayoutData();
     gd.exclude = false;
-    getParent().requestLayout();
-  }
-
-  /**
-   * Hide the banner.
-   */
-  public void hide() {
-    if (isDisposed()) {
-      return;
-    }
-    setVisible(false);
-    GridData gd = (GridData) getLayoutData();
-    gd.exclude = true;
     getParent().requestLayout();
   }
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/i18n/Messages.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/i18n/Messages.java
@@ -198,6 +198,9 @@ public final class Messages extends NLS {
   public static String context_window_messages;
   public static String context_window_files;
   public static String context_window_tool_results;
+  public static String chat_staticBanner_messageWithLink;
+  public static String chat_rateLimitBanner_getMoreInfo;
+  public static String chat_rateLimitBanner_closeTooltip;
 
   static {
     // initialize resource bundle

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/i18n/messages.properties
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/i18n/messages.properties
@@ -194,3 +194,7 @@ context_window_user_context=User Context
 context_window_messages=Messages
 context_window_files=Attached Files
 context_window_tool_results=Tool Results
+
+chat_staticBanner_messageWithLink={0} <a>{1}</a>
+chat_rateLimitBanner_getMoreInfo=Get more info
+chat_rateLimitBanner_closeTooltip=Dismiss


### PR DESCRIPTION
Test:
1. With handoff:
<img width="606" height="729" alt="image" src="https://github.com/user-attachments/assets/d7b6c1b3-6224-4430-a1a9-7ec50da67179" />

2. Without handoff:
<img width="600" height="275" alt="image" src="https://github.com/user-attachments/assets/162ec215-22d5-4750-8174-a411145b8466" />

3. The banner should be hide/unhide when check chat history.
