### PR TITLE
feat - update BYOK disable tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add rate limit warning banner in chat view. [PR#17](https://github.com/microsoft/copilot-for-eclipse/pull/17)
 - Support delegating read directory to IDE. [PR#18](https://github.com/microsoft/copilot-for-eclipse/pull/18)
 - Support delegating file and text search to IDE. [PR#22](https://github.com/microsoft/copilot-for-eclipse/pull/22)
+- Support custom models (BYOK) for Copilot Business and Enterprise users. [PR#140](https://github.com/microsoft/copilot-for-eclipse/pull/140)
 
 ### Changed
 - Update the combos rendering and add context button style in chat view.
-- Support custom models (BYOK) for Copilot Business and Enterprise users.
 
 ### Fixed
 - Fix ConcurrentModificationException in CompletionProvider listener iteration. [PR#13](https://github.com/microsoft/copilot-for-eclipse/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update the combos rendering and add context button style in chat view.
+- Support custom models (BYOK) for Copilot Business and Enterprise users.
 
 ### Fixed
 - Fix ConcurrentModificationException in CompletionProvider listener iteration. [PR#13](https://github.com/microsoft/copilot-for-eclipse/pull/13)

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ByokPreferencePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ByokPreferencePage.java
@@ -178,7 +178,7 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
     disabledCompositeLayout.marginHeight = 0;
     disabledComposite.setLayout(disabledCompositeLayout);
     WrappableIconLink.createWithCustomizedImage(disabledComposite, "/icons/information.png",
-        Messages.preferences_page_byok_preview_disabled_tip);
+        Messages.preferences_page_byok_disabled_tip);
     contentComposite = createByokView(pageStateStack);
     updatePageState();
     root.addDisposeListener(e -> {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/Messages.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/Messages.java
@@ -46,7 +46,7 @@ public class Messages extends NLS {
   public static String preferences_page_byok_dialog_remove;
   public static String preferences_page_byok_customModels;
   public static String preferences_page_byok_enabledCount;
-  public static String preferences_page_byok_preview_disabled_tip;
+  public static String preferences_page_byok_disabled_tip;
   public static String preferences_page_completions_codeMiningNote;
   public static String preferences_page_customModes_defaultDescription;
   public static String preferences_page_customModes_defaultInstructions;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/messages.properties
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/messages.properties
@@ -34,7 +34,7 @@ preferences_page_byok_dialog_cancel=Cancel
 preferences_page_byok_dialog_remove=Remove
 preferences_page_byok_customModels=Custom Models
 preferences_page_byok_enabledCount=%s of %s Enabled
-preferences_page_byok_disabled_tip=Custom models are disabled by your enterprise GitHub settings. Please contact your organization's administrator for more information.
+preferences_page_byok_disabled_tip=Custom models are disabled by your organization's GitHub settings. Please contact your organization's administrator for more information.
 preferences_page_completions_codeMiningNote= You need to enable <a>'Code Minings'</a> to use inline completions in Eclipse 2024-12 (4.34) and later.
 
 preferences_page_customModes_defaultDescription=Describe what this custom agent does and when to use it.

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/messages.properties
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/messages.properties
@@ -34,7 +34,7 @@ preferences_page_byok_dialog_cancel=Cancel
 preferences_page_byok_dialog_remove=Remove
 preferences_page_byok_customModels=Custom Models
 preferences_page_byok_enabledCount=%s of %s Enabled
-preferences_page_byok_preview_disabled_tip=Custom models are available to Individual Copilot Users (Pro+, Pro and Free) who have enabled the Editor preview features in their Copilot Settings.
+preferences_page_byok_disabled_tip=Custom models are disabled by your enterprise GitHub settings. Please contact your organization's administrator for more information.
 preferences_page_completions_codeMiningNote= You need to enable <a>'Code Minings'</a> to use inline completions in Eclipse 2024-12 (4.34) and later.
 
 preferences_page_customModes_defaultDescription=Describe what this custom agent does and when to use it.


### PR DESCRIPTION


BYOK now supports Copilot Business and Enterprise users when enabled by their organization (see https://github.com/microsoft/copilot-language-server-internal/pull/733). This PR updates the tip to reflect this change.