### PR TITLE
Fix 400 Bad Request when restoring conversation from persistence

### DIFF
--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
@@ -298,9 +298,9 @@ public class CopilotLanguageServerConnection {
         param.setWorkspaceFolder(agentJobWorkspaceFolder);
       }
 
-      // Set historical turns if provided.
+      // Set historical turns if provided, inserting them before the current user message.
       if (turns != null && turns.size() > 0) {
-        param.getTurns().addAll(turns);
+        param.getTurns().addAll(0, turns);
       }
 
       // TODO: remove needToolCallConfirmation when CLS fully supports it across all IDEs.

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
@@ -286,21 +286,21 @@ public class CopilotLanguageServerConnection {
       param.setChatMode(chatModeName);
       param.setCustomChatModeId(customChatModeId);
 
+      // Set historical turns if provided, inserting them before the current user message.
+      if (turns != null && turns.size() > 0) {
+        param.getTurns().addAll(0, turns);
+      }
+
       if (StringUtils.isBlank(agentSlug)) {
         param.setWorkspaceFolder(PlatformUtils.getWorkspaceRootUri());
         param.setWorkspaceFolders(LSPEclipseUtils.getWorkspaceFolders());
         param.setTodoList(todos);
       } else {
-        // Set agentSlug if provided - this will modify the first turn's agentSlug
+        // Set agentSlug on the last turn (current user message) after history insertion
         if (param.getTurns() != null && !param.getTurns().isEmpty()) {
-          param.getTurns().get(0).setAgentSlug(agentSlug);
+          param.getTurns().get(param.getTurns().size() - 1).setAgentSlug(agentSlug);
         }
         param.setWorkspaceFolder(agentJobWorkspaceFolder);
-      }
-
-      // Set historical turns if provided, inserting them before the current user message.
-      if (turns != null && turns.size() > 0) {
-        param.getTurns().addAll(0, turns);
       }
 
       // TODO: remove needToolCallConfirmation when CLS fully supports it across all IDEs.

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -26,7 +26,7 @@ import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ErrorMessa
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ToolCallData;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
-import com.microsoft.copilot.eclipse.core.utils.ChatMessageUtils;
+
 
 /**
  * Factory for creating and transforming conversation data objects. Responsible only for pure data transformation with
@@ -221,9 +221,8 @@ public class ConversationDataFactory {
         // TODO: We don't persist images for now, so hard code the modelSupportVersion to false. In the future, handle
         // images in responses and pass the model support version here if needed.
         String responseText = extractResponseFromCopilotTurnData(copilotTurnData);
-        Either<String, List<ChatCompletionContentPart>> response = ChatMessageUtils
-            .createMessageWithImages(responseText, new ArrayList<>(), false);
-        result.add(new Turn(response, responseText, null));
+        Either<String, List<ChatCompletionContentPart>> request = Either.forLeft("");
+        result.add(new Turn(request, responseText, null));
       }
     }
     return result;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -218,8 +218,7 @@ public class ConversationDataFactory {
             .forLeft(requestText == null ? "" : requestText);
         result.add(new Turn(request, null, null));
       } else if (turnData instanceof CopilotTurnData copilotTurnData) {
-        // TODO: We don't persist images for now, so hard code the modelSupportVersion to false. In the future, handle
-        // images in responses and pass the model support version here if needed.
+        // Assistant turns only contribute the response text; the request field is intentionally empty.
         String responseText = extractResponseFromCopilotTurnData(copilotTurnData);
         Either<String, List<ChatCompletionContentPart>> request = Either.forLeft("");
         result.add(new Turn(request, responseText, null));


### PR DESCRIPTION
fix https://github.com/microsoft/copilot-for-eclipse/issues/131

When restoring a history-based conversation, the first request to the LLM intermittently fails with a 400 Bad Request error. Two issues were found:

### 1. Assistant response duplicated as user message
In `ConversationDataFactory.convertToTurns()`, the assistant's response text was incorrectly assigned to the `request` field of the `Turn` object, causing the LLM's previous reply to appear as a `role: "user"` message in the history.

**Fix:** Use an empty string for the `request` field on assistant turns, keeping the response text only in the `response` field.

### 2. New user message not appended at the end
In `CopilotLanguageServerConnection.createConversation()`, historical turns were appended **after** the current user message (`addAll(turns)`). Since `ConversationCreateParams` places the current user message as the first turn, this resulted in the messages array ending with an assistant role message. Claude API requires the last message to be `role: "user"`, causing a 400 error.

**Fix:** Insert historical turns **before** the current user message using `addAll(0, turns)`.