### PR TITLE
fix: harden MCP extension-point registration against races and stale state

### DIFF
--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/events/CopilotEventConstants.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/events/CopilotEventConstants.java
@@ -147,6 +147,17 @@ public class CopilotEventConstants {
   public static final String TOPIC_MCP_SERVER_STATE_CHANGE = TOPIC_MCP + "SERVER_STATE_CHANGE";
 
   /**
+   * Event when the MCP registration extension-point manager has finished detecting and verifying
+   * the contributed servers (either at startup or after a policy toggle / user approval) and the
+   * approved-servers JSON for the language server is ready to be pushed.
+   *
+   * <p>Payload (via {@code IEventBroker.DATA}): the approved-servers JSON {@code String}, or
+   * {@code null} when no extension-contributed servers are approved.
+   */
+  public static final String TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED = TOPIC_MCP
+      + "EXTENSION_POINT_REGISTRATION_COMPLETED";
+
+  /**
    * Event when NES suggestion is accepted.
    */
   public static final String TOPIC_NES_ACCEPT_SUGGESTION = TOPIC_NES + "ACCEPT_SUGGESTION";

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManagerTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManagerTest.java
@@ -335,8 +335,26 @@ class McpExtensionPointManagerTest {
   }
 
   private void invokeDetectChanges(Map<String, McpRegistrationInfo> persisted) throws Exception {
-    Method detectMethod = McpExtensionPointManager.class.getDeclaredMethod("detectChangesInMcpContribs", Map.class);
+    // Get the scanned map that was previously set via setExtMcpInfoMap
+    Field field = McpExtensionPointManager.class.getDeclaredField("extMcpInfoMap");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<String, McpRegistrationInfo> scannedMap = (Map<String, McpRegistrationInfo>) field.get(manager);
+
+    // detectChangesInMcpContribs now takes (scannedMap, persistedMap) and no longer
+    // calls updateApprovedMcpServerString / persistExtMcpInfo (those moved to doRegistration).
+    Method detectMethod = McpExtensionPointManager.class.getDeclaredMethod("detectChangesInMcpContribs", Map.class,
+        Map.class);
     detectMethod.setAccessible(true);
-    detectMethod.invoke(manager, persisted);
+    detectMethod.invoke(manager, scannedMap, persisted);
+
+    // Mirror what doRegistration() does after detectChanges: swap the field and update/persist.
+    field.set(manager, scannedMap);
+    Method updateMethod = McpExtensionPointManager.class.getDeclaredMethod("updateApprovedMcpServerString", Map.class);
+    updateMethod.setAccessible(true);
+    updateMethod.invoke(manager, scannedMap);
+    Method persistMethod = McpExtensionPointManager.class.getDeclaredMethod("persistExtMcpInfo", Map.class);
+    persistMethod.setAccessible(true);
+    persistMethod.invoke(manager, scannedMap);
   }
 }

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManagerTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManagerTest.java
@@ -4,10 +4,13 @@
 package com.microsoft.copilot.eclipse.ui.chat.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -206,5 +209,134 @@ class McpExtensionPointManagerTest {
     Map<String, Object> result = gson.fromJson(approvedServers, Map.class);
     Map<String, Object> resultServers = (Map<String, Object>) result.get("servers");
     assertTrue(resultServers.isEmpty(), "Servers map should be empty when MCP servers are null");
+  }
+
+  @Test
+  void testDetectChangesDropsApprovedServerWhenPluginUninstalled() throws Exception {
+    // Regression test for https://github.com/microsoft/copilot-for-eclipse/issues/153 scenario 1:
+    // a previously approved plugin is no longer providing any MCP server.
+    IPreferenceStore mockPreferenceStore = mock(IPreferenceStore.class);
+    when(mockCopilotUi.getPreferenceStore()).thenReturn(mockPreferenceStore);
+
+    Map<String, Object> previouslyApprovedServers = new HashMap<>();
+    previouslyApprovedServers.put("server-X", Map.of("url", "http://localhost:9000"));
+    McpRegistrationInfo persistedInfo = createMcpRegistrationInfo(true, true, "Test Plugin",
+        previouslyApprovedServers);
+    Map<String, McpRegistrationInfo> persisted = new HashMap<>();
+    persisted.put("com.example.plugin", persistedInfo);
+
+    // Live extension scan returned nothing (plugin uninstalled or no longer provides servers).
+    setExtMcpInfoMap(new HashMap<>());
+
+    invokeDetectChanges(persisted);
+
+    String approvedServers = manager.getApprovedExtMcpServers();
+    assertNotNull(approvedServers, "Approved servers JSON should be non-null after detect");
+    Map<String, Object> result = gson.fromJson(approvedServers, Map.class);
+    Map<String, Object> resultServers = (Map<String, Object>) result.get("servers");
+    assertTrue(resultServers.isEmpty(),
+        "Stale approved server must be dropped when the live extension scan returns nothing");
+
+    // No new approval prompt should be raised because there is no incoming registration to approve.
+    verify(mockMcpConfigService, never()).setNewExtMcpRegFound(true);
+
+    // The verified state must be persisted so subsequent startups do not resurrect the stale entry.
+    ArgumentCaptor<String> persistedJson = ArgumentCaptor.forClass(String.class);
+    verify(mockPreferenceStore, atLeastOnce()).setValue(eq(Constants.MCP_EXTENSION_POINT_CONTRIB),
+        persistedJson.capture());
+    assertEquals("{}", persistedJson.getValue(),
+        "Persisted contribution map should be empty after the plugin is gone");
+  }
+
+  @Test
+  void testDetectChangesDropsApprovalAndFlagsRedNoticeWhenConfigChanges() throws Exception {
+    // Regression test for https://github.com/microsoft/copilot-for-eclipse/issues/153 scenario 2:
+    // the contributing plugin returns a different config than what was previously approved.
+    IPreferenceStore mockPreferenceStore = mock(IPreferenceStore.class);
+    when(mockCopilotUi.getPreferenceStore()).thenReturn(mockPreferenceStore);
+
+    Map<String, Object> oldServers = new HashMap<>();
+    oldServers.put("server-X", Map.of("url", "http://localhost:9000"));
+    McpRegistrationInfo persistedInfo = createMcpRegistrationInfo(true, true, "Test Plugin", oldServers);
+    Map<String, McpRegistrationInfo> persisted = new HashMap<>();
+    persisted.put("com.example.plugin", persistedInfo);
+
+    // Live extension scan returned the same plugin but with a different server config (port change).
+    Map<String, Object> newServers = new HashMap<>();
+    newServers.put("server-X", Map.of("url", "http://localhost:9999"));
+    McpRegistrationInfo currentInfo = createMcpRegistrationInfo(true, false, "Test Plugin", newServers);
+    Map<String, McpRegistrationInfo> currentMap = new HashMap<>();
+    currentMap.put("com.example.plugin", currentInfo);
+    setExtMcpInfoMap(currentMap);
+
+    invokeDetectChanges(persisted);
+
+    String approvedServers = manager.getApprovedExtMcpServers();
+    assertNotNull(approvedServers);
+    Map<String, Object> result = gson.fromJson(approvedServers, Map.class);
+    Map<String, Object> resultServers = (Map<String, Object>) result.get("servers");
+    assertTrue(resultServers.isEmpty(),
+        "Changed config must not be auto-applied; LSP must not receive the (now unapproved) entry");
+
+    assertFalse(currentInfo.isApproved(),
+        "Previously approved entry whose config changed must be marked as unapproved until the user re-approves");
+    verify(mockMcpConfigService).setNewExtMcpRegFound(true);
+    verify(mockPreferenceStore, atLeastOnce()).setValue(eq(Constants.MCP_EXTENSION_POINT_CONTRIB),
+        org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void testDetectChangesPreservesApprovalWhenConfigUnchanged() throws Exception {
+    // Companion test: when the live extension scan reports the same config as the persisted cache,
+    // the previous approval must be carried over so the explicit LSP sync at the end of
+    // doRegistration() can push the verified servers to the language server.
+    IPreferenceStore mockPreferenceStore = mock(IPreferenceStore.class);
+    when(mockCopilotUi.getPreferenceStore()).thenReturn(mockPreferenceStore);
+
+    Map<String, Object> approvedServers = new HashMap<>();
+    approvedServers.put("server-X", Map.of("url", "http://localhost:9000"));
+    McpRegistrationInfo persistedInfo = createMcpRegistrationInfo(true, true, "Test Plugin", approvedServers);
+    Map<String, McpRegistrationInfo> persisted = new HashMap<>();
+    persisted.put("com.example.plugin", persistedInfo);
+
+    // Live extension scan returned the same servers; default isApproved=false until carry-over runs.
+    Map<String, Object> sameServers = new HashMap<>();
+    sameServers.put("server-X", Map.of("url", "http://localhost:9000"));
+    McpRegistrationInfo currentInfo = createMcpRegistrationInfo(true, false, "Test Plugin", sameServers);
+    Map<String, McpRegistrationInfo> currentMap = new HashMap<>();
+    currentMap.put("com.example.plugin", currentInfo);
+    setExtMcpInfoMap(currentMap);
+
+    invokeDetectChanges(persisted);
+
+    assertTrue(currentInfo.isApproved(),
+        "When the contributed config matches the persisted JSON, the previous approval must be carried over");
+
+    String approvedJson = manager.getApprovedExtMcpServers();
+    assertNotNull(approvedJson);
+    Map<String, Object> result = gson.fromJson(approvedJson, Map.class);
+    Map<String, Object> resultServers = (Map<String, Object>) result.get("servers");
+    assertEquals(1, resultServers.size(),
+        "Carried-over approved server must be present in the approved servers JSON for the LSP sync");
+
+    // No red-notice should be raised because nothing has changed for the user to re-review.
+    verify(mockMcpConfigService, never()).setNewExtMcpRegFound(true);
+  }
+
+  /**
+   * Reflectively replace the manager's private {@code extMcpInfoMap} so tests can simulate the
+   * outcome of {@code loadMcpRegistrationExtensionPoint()} without requiring a live OSGi
+   * extension registry.
+   */
+  private void setExtMcpInfoMap(Map<String, McpRegistrationInfo> map) throws Exception {
+    Field field = McpExtensionPointManager.class.getDeclaredField("extMcpInfoMap");
+    field.setAccessible(true);
+    field.set(manager, map);
+  }
+
+  private void invokeDetectChanges(Map<String, McpRegistrationInfo> persisted) throws Exception {
+    Method detectMethod = McpExtensionPointManager.class.getDeclaredMethod("detectChangesInMcpContribs", Map.class);
+    detectMethod.setAccessible(true);
+    detectMethod.invoke(manager, persisted);
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
@@ -1030,10 +1030,7 @@ public class ActionBar extends Composite implements NewConversationListener {
     approvalItem.addSelectionListener(new SelectionAdapter() {
       @Override
       public void widgetSelected(SelectionEvent e) {
-        String res = chatServiceManager.getMcpExtensionPointManager().approveExtMcpRegistration();
-        if (StringUtils.isNotBlank(res)) {
-          CopilotUi.getPlugin().getLanguageServerSettingManager().syncMcpRegistrationConfiguration();
-        }
+        chatServiceManager.getMcpExtensionPointManager().approveExtMcpRegistration();
       }
     });
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
@@ -52,11 +52,12 @@ public class McpExtensionPointManager {
   private static final String ELEMENT_PROVIDER = "provider";
   private static final String ATTRIBUTE_CLASS = "class";
 
-  private String approvedExtMcpServers;
+  private volatile String approvedExtMcpServers;
   private Map<String, McpRegistrationInfo> extMcpInfoMap = new HashMap<>(); // Key: Plugin-Id(Bundle)
 
   private McpConfigService mcpConfigService;
   private Gson gson;
+  private IEventBroker eventBroker;
 
   /**
    * Constructor for McpExtensionPointManager.
@@ -64,28 +65,36 @@ public class McpExtensionPointManager {
   public McpExtensionPointManager(McpConfigService mcpConfigService) {
     gson = new GsonBuilder().disableHtmlEscaping().create();
     this.mcpConfigService = mcpConfigService;
+    this.eventBroker = PlatformUI.getWorkbench().getService(IEventBroker.class);
 
     if (CopilotCore.getPlugin().getFeatureFlags().isMcpContributionPointEnabled()) {
       initializeExtMcpRegistration();
     }
-    IEventBroker eventBroker = PlatformUI.getWorkbench().getService(IEventBroker.class);
     eventBroker.subscribe(CopilotEventConstants.TOPIC_DID_CHANGE_MCP_CONTRIBUTION_POINT_POLICY, event -> {
       Boolean enabled = (Boolean) event.getProperty(IEventBroker.DATA);
       if (enabled.booleanValue()) {
         initializeExtMcpRegistration();
       } else {
-        extMcpInfoMap.clear();
-        approvedExtMcpServers = null;
-        persistExtMcpInfo(extMcpInfoMap);
-        mcpConfigService.setNewExtMcpRegFound(false);
+        // Disabling the contribution point clears the in-memory state shared with doRegistration().
+        // Hold the manager monitor so the (non-thread-safe) HashMap clear and the approved-servers
+        // reset are not observed mid-update by a concurrent doRegistration() running on the async
+        // worker.
+        synchronized (this) {
+          extMcpInfoMap.clear();
+          approvedExtMcpServers = null;
+          persistExtMcpInfo(extMcpInfoMap);
+          mcpConfigService.setNewExtMcpRegFound(false);
+        }
       }
     });
   }
 
   private synchronized void initializeExtMcpRegistration() {
-    // Previously approved servers will be started during Plugin startup.
+    // Avoid pre-populating the in-memory approved servers from the persisted cache. If we did so,
+    // the initial syncMcpRegistrationConfiguration() at startup would push potentially stale data
+    // (server removed by the contributing plugin, port changed, plugin uninstalled) to the language
+    // server, which would surface a connection failure before doRegistration() can refresh the state.
     Map<String, McpRegistrationInfo> persistedMcpContribs = loadPersistedMcpContribs();
-    updateApprovedMcpServerString(persistedMcpContribs);
 
     // Run the heavy initialization work asynchronously, which has weak relation with Plugin startup.
     CompletableFuture.runAsync(() -> {
@@ -93,16 +102,37 @@ public class McpExtensionPointManager {
     });
   }
 
-  private synchronized void doRegistration(Map<String, McpRegistrationInfo> persistedMcpContribs) {
+  private void doRegistration(Map<String, McpRegistrationInfo> persistedMcpContribs) {
+    String approvedServersToPublish = null;
+    boolean shouldPublish = false;
     try {
-      FeatureFlags flags = CopilotCore.getPlugin().getFeatureFlags();
-      if (flags != null && !flags.isMcpEnabled()) {
-        return;
+      synchronized (this) {
+        FeatureFlags flags = CopilotCore.getPlugin().getFeatureFlags();
+        if (flags != null && !flags.isMcpEnabled()) {
+          return;
+        }
+        loadMcpRegistrationExtensionPoint();
+        detectChangesInMcpContribs(persistedMcpContribs);
+        approvedServersToPublish = approvedExtMcpServers;
+        shouldPublish = true;
       }
-      loadMcpRegistrationExtensionPoint();
-      detectChangesInMcpContribs(persistedMcpContribs);
     } catch (Exception e) {
       CopilotCore.LOGGER.error("Error during EXT MCP registration initialization", e);
+      return;
+    }
+    // Publish the verified state outside the synchronized section so the manager monitor is not
+    // held while subscribers (notably LanguageServerSettingManager) push to the language server.
+    // The event fires unconditionally on success - including when the persisted JSON is unchanged
+    // and IPreferenceStore.setValue() therefore short-circuits its property-change notification -
+    // so the LSP always receives the verified extension-contributed servers.
+    if (shouldPublish) {
+      publishRegistrationCompleted(approvedServersToPublish);
+    }
+  }
+
+  private void publishRegistrationCompleted(String approvedServersJson) {
+    if (eventBroker != null) {
+      eventBroker.post(CopilotEventConstants.TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED, approvedServersJson);
     }
   }
 
@@ -167,7 +197,7 @@ public class McpExtensionPointManager {
         CopilotCore.LOGGER.error("Cannot find bundle: " + bundleName, null);
         continue; // Skip inactive plug-ins
       }
-      if (bundle.getState() != Bundle.ACTIVE || bundle.getState() != Bundle.STARTING) {
+      if (bundle.getState() != Bundle.ACTIVE && bundle.getState() != Bundle.STARTING) {
         try {
           bundle.start(Bundle.START_ACTIVATION_POLICY);
         } catch (BundleException e) {
@@ -297,12 +327,8 @@ public class McpExtensionPointManager {
       mcpConfigService.setNewExtMcpRegFound(true);
     }
 
-    // Always persist the latest MCP registration info, in case some plug-ins are un-installed, or unregister MCP
-    // servers.
-    if (!extMcpInfoMap.equals(existingExtMcpInfoMap)) {
-      updateApprovedMcpServerString(extMcpInfoMap);
-      persistExtMcpInfo(extMcpInfoMap);
-    }
+    updateApprovedMcpServerString(extMcpInfoMap);
+    persistExtMcpInfo(extMcpInfoMap);
   }
 
   /**
@@ -310,18 +336,35 @@ public class McpExtensionPointManager {
    */
   public String approveExtMcpRegistration() {
     Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-    if (extMcpInfoMap.isEmpty()) {
-      MessageDialog.openInformation(shell, "", "No MCP server registration found");
-      return null;
+    Map<String, McpRegistrationInfo> dialogInput;
+    synchronized (this) {
+      if (extMcpInfoMap.isEmpty()) {
+        MessageDialog.openInformation(shell, "", "No MCP server registration found");
+        return null;
+      }
+      // Take a shallow snapshot so the dialog can iterate the map safely even if doRegistration()
+      // mutates extMcpInfoMap on the async worker. Approval flips happen on the McpRegistrationInfo
+      // value objects, which are shared between the snapshot and the live map by reference, so the
+      // user's choices are reflected in extMcpInfoMap once the dialog returns.
+      dialogInput = new HashMap<>(extMcpInfoMap);
     }
 
-    McpApprovalDialog dialog = new McpApprovalDialog(shell, extMcpInfoMap);
+    // Open the modal dialog outside the synchronized block so a concurrent doRegistration() worker
+    // is not stalled on this manager's monitor while the user interacts with the dialog.
+    McpApprovalDialog dialog = new McpApprovalDialog(shell, dialogInput);
     dialog.open();
 
-    mcpConfigService.setNewExtMcpRegFound(false); // Reset the flag after user approval
-    updateApprovedMcpServerString(extMcpInfoMap);
-    persistExtMcpInfo(extMcpInfoMap);
-    return approvedExtMcpServers;
+    String approvedJson;
+    synchronized (this) {
+      mcpConfigService.setNewExtMcpRegFound(false); // Reset the flag after user approval
+      updateApprovedMcpServerString(extMcpInfoMap);
+      persistExtMcpInfo(extMcpInfoMap);
+      approvedJson = approvedExtMcpServers;
+    }
+    // Publish outside the lock so subscribers (notably LanguageServerSettingManager) are not
+    // running their LSP push while the manager monitor is held.
+    publishRegistrationCompleted(approvedJson);
+    return approvedJson;
   }
 
   private void persistExtMcpInfo(Map<String, McpRegistrationInfo> extMcpInfoMap) {
@@ -396,7 +439,7 @@ public class McpExtensionPointManager {
   /**
    * Check if there is any MCP registration from extension point.
    */
-  public boolean hasExtMcpRegistration() {
+  public synchronized boolean hasExtMcpRegistration() {
     return !extMcpInfoMap.isEmpty();
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
@@ -106,13 +106,18 @@ public class McpExtensionPointManager {
     String approvedServersToPublish = null;
     boolean shouldPublish = false;
     try {
+      FeatureFlags flags = CopilotCore.getPlugin().getFeatureFlags();
+      if (flags != null && !flags.isMcpEnabled()) {
+        return;
+      }
+      // Perform the slow extension-point scan and diff work outside the lock so that
+      // UI-thread callers (e.g. approveExtMcpRegistration) are not blocked.
+      Map<String, McpRegistrationInfo> scannedMap = loadMcpRegistrationExtensionPoint();
+      detectChangesInMcpContribs(scannedMap, persistedMcpContribs);
       synchronized (this) {
-        FeatureFlags flags = CopilotCore.getPlugin().getFeatureFlags();
-        if (flags != null && !flags.isMcpEnabled()) {
-          return;
-        }
-        loadMcpRegistrationExtensionPoint();
-        detectChangesInMcpContribs(persistedMcpContribs);
+        extMcpInfoMap = scannedMap;
+        updateApprovedMcpServerString(extMcpInfoMap);
+        persistExtMcpInfo(extMcpInfoMap);
         approvedServersToPublish = approvedExtMcpServers;
         shouldPublish = true;
       }
@@ -181,11 +186,12 @@ public class McpExtensionPointManager {
   /**
    * Load MCP registration from extension point.
    */
-  private void loadMcpRegistrationExtensionPoint() {
+  private Map<String, McpRegistrationInfo> loadMcpRegistrationExtensionPoint() {
+    Map<String, McpRegistrationInfo> result = new HashMap<>();
     IExtensionRegistry registry = Platform.getExtensionRegistry();
     IExtensionPoint extensionPoint = registry.getExtensionPoint(EXTENSION_POINT_ID);
     if (extensionPoint == null) {
-      return;
+      return result;
     }
 
     // Traverse all extensions/bundles.
@@ -251,9 +257,10 @@ public class McpExtensionPointManager {
 
       // Update registration info
       if (!mergedServers.isEmpty()) {
-        extMcpInfoMap.put(bundleName, new McpRegistrationInfo(isTrusted, isApproved, pluginDisplayName, mergedServers));
+        result.put(bundleName, new McpRegistrationInfo(isTrusted, isApproved, pluginDisplayName, mergedServers));
       }
     }
+    return result;
   }
 
   /**
@@ -298,14 +305,16 @@ public class McpExtensionPointManager {
   /**
    * Detect changes in MCP registration from extension point compared to the existing record.
    */
-  private void detectChangesInMcpContribs(Map<String, McpRegistrationInfo> existingExtMcpInfoMap) {
+  private void detectChangesInMcpContribs(
+      Map<String, McpRegistrationInfo> scannedMap,
+      Map<String, McpRegistrationInfo> existingExtMcpInfoMap) {
     boolean newExtMcpRegFound = false;
     if (existingExtMcpInfoMap == null) {
       existingExtMcpInfoMap = Collections.emptyMap();
     }
 
     // Compare each plugin's current MCP servers with the stored record
-    for (Map.Entry<String, McpRegistrationInfo> entry : extMcpInfoMap.entrySet()) {
+    for (Map.Entry<String, McpRegistrationInfo> entry : scannedMap.entrySet()) {
       String contributorName = entry.getKey();
       McpRegistrationInfo mcpRegistrationInfo = entry.getValue();
       McpRegistrationInfo storedInfo = existingExtMcpInfoMap.get(contributorName);
@@ -326,9 +335,6 @@ public class McpExtensionPointManager {
     if (newExtMcpRegFound) {
       mcpConfigService.setNewExtMcpRegFound(true);
     }
-
-    updateApprovedMcpServerString(extMcpInfoMap);
-    persistExtMcpInfo(extMcpInfoMap);
   }
 
   /**

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
@@ -103,6 +103,8 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
         syncMcpRegistrationConfiguration();
       }
     });
+    eventBroker.subscribe(CopilotEventConstants.TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED,
+        event -> syncMcpRegistrationConfiguration((String) event.getProperty(IEventBroker.DATA)));
   }
 
   /**
@@ -140,7 +142,7 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
         settings.getGithubEnterprise().setUri(preferenceStore.getString(Constants.GITHUB_ENTERPRISE));
         singleSetting = new CopilotLanguageServerSettings(null, null, settings.getGithubEnterprise(), null);
         break;
-      case Constants.MCP, Constants.MCP_EXTENSION_POINT_CONTRIB:
+      case Constants.MCP:
         syncMcpRegistrationConfiguration();
         return;
       case Constants.MCP_TOOLS_STATUS:
@@ -206,13 +208,40 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
    * Sync MCP registration from both extension points and preference store.
    */
   public void syncMcpRegistrationConfiguration() {
+    String approvedExtMcpServers = null;
+    if (CopilotCore.getPlugin().getFeatureFlags().isMcpContributionPointEnabled()) {
+      // Defensive null-chain: callers from very early startup paths (e.g. CopilotUi.start()) may
+      // run before the ChatServiceManager singleton field is assigned. The extension-point flow
+      // delivers its own state via TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED, so missing it
+      // here just means the LSP gets the manual MCP state for now and the verified state arrives
+      // shortly after via that subscription.
+      var chatServiceManager = CopilotUi.getPlugin().getChatServiceManager();
+      if (chatServiceManager != null) {
+        McpExtensionPointManager mgr = chatServiceManager.getMcpExtensionPointManager();
+        if (mgr != null) {
+          approvedExtMcpServers = mgr.getApprovedExtMcpServers();
+        }
+      }
+    }
+    syncMcpRegistrationConfiguration(approvedExtMcpServers);
+  }
+
+  /**
+   * Sync MCP registration to the language server using the supplied extension-contributed approved
+   * servers JSON. Used by callers that already have the approved JSON in hand - notably the
+   * subscriber to {@link CopilotEventConstants#TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED} -
+   * so they do not need to traverse {@code CopilotUi.getChatServiceManager()} to look it up.
+   *
+   * @param approvedExtMcpServers JSON for the approved extension-contributed MCP servers, or
+   *     {@code null} when none are approved or the contribution point is disabled.
+   */
+  public void syncMcpRegistrationConfiguration(String approvedExtMcpServers) {
     // From manual configuration
     settings.setMcpServers(preferenceStore.getString(Constants.MCP));
 
     // From McpRegistration extension point
     if (CopilotCore.getPlugin().getFeatureFlags().isMcpContributionPointEnabled()) {
-      McpExtensionPointManager mgr = CopilotUi.getPlugin().getChatServiceManager().getMcpExtensionPointManager();
-      settings.addMcpServers(mgr.getApprovedExtMcpServers());
+      settings.addMcpServers(approvedExtMcpServers);
     }
 
     syncSingleConfiguration(new CopilotLanguageServerSettings(null, null, null, settings.getGithubSettings()));

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpPreferencePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpPreferencePage.java
@@ -431,11 +431,7 @@ public class McpPreferencePage extends FieldEditorPreferencePage implements IWor
     extMcpButton.addSelectionListener(new SelectionAdapter() {
       @Override
       public void widgetSelected(SelectionEvent e) {
-        String res = CopilotUi.getPlugin().getChatServiceManager().getMcpExtensionPointManager()
-            .approveExtMcpRegistration();
-        if (StringUtils.isNotBlank(res)) {
-          CopilotUi.getPlugin().getLanguageServerSettingManager().syncMcpRegistrationConfiguration();
-        }
+        CopilotUi.getPlugin().getChatServiceManager().getMcpExtensionPointManager().approveExtMcpRegistration();
       }
     });
   }


### PR DESCRIPTION
- Synchronize all extMcpInfoMap accesses on the manager monitor so the HashMap is never iterated/mutated concurrently by the async doRegistration() worker, the contribution-point-policy event handler, and the UI-thread approval flow.
- approveExtMcpRegistration() now snapshots the map under the lock and opens McpApprovalDialog outside the lock so the worker is not stalled while the user interacts; post-dialog reconciliation re-acquires the lock and the LSP-pushing event publish runs outside the lock.
- Mark approvedExtMcpServers volatile and make hasExtMcpRegistration() synchronized for consistent visibility from the UI thread.
- Avoid pre-populating in-memory approved servers from the persisted cache at startup; let doRegistration() refresh state and fire TOPIC_MCP_EXTENSION_POINT_REGISTRATION_COMPLETED so the LSP receives the verified set instead of stale data (uninstalled plugin, changed port, removed server).
- Fix bundle-state guard in loadMcpRegistrationExtensionPoint() (|| -> &&) so already-active or starting bundles are not pointlessly started again.
- LanguageServerSettingManager subscribes to the new completion topic and exposes an overload that accepts the approved JSON directly, avoiding the ChatServiceManager lookup from early-startup paths.
- Add regression tests covering plugin uninstall, config change (re-approval required), and unchanged config (approval carry-over).

Issue: https://github.com/microsoft/copilot-for-eclipse/issues/153