### PR TITLE
Extend CONTRIBUTING.md and adapt some Eclipse project settings to simplify getting started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,7 @@ The installable P2 repository is generated in `com.microsoft.copilot.eclipse.rep
    * Select *File > Import... > General > Existing projects into Workspace*,
      select the root directory of the copilot-for-eclipse git repo,
      activate the check box *Search for nested projects*, and finish the wizard.
-   * Do import additional projects using the import wizard for Maven project (without a `.project` file):
-     Select *File > Import... > Maven > Existing Maven Projects*,
-   * Do also import the agent bundle for your OS (e.g., `com.microsoft.copilot.eclipse.core.agent.win-x64`)
+   * Do also import the agent bundle for your OS (e.g., `com.microsoft.copilot.eclipse.core.agent.win32`)
      after building the project with npm and maven or import all OS-specific agent bundles.
 2. Activate one of the target platforms, i.e. open one of the target definition files and select `Set As Active Target Platform`.
    * target-terminal.target (Eclipse 4.37+)
@@ -71,7 +69,7 @@ The installable P2 repository is generated in `com.microsoft.copilot.eclipse.rep
    * Select Type="Project Relative Configuration", **name="copilot4eclipse"**, and choose the location using the *Browse...* button.
      The `checkstyle.xml` file is in the git repository root folder in the project "github-copilot-for-eclipse".
 4. Use the launch configurations in the `launch/` directory, e.g. for launching a new Eclipse IDE with Copilot plug-ins.
-   * Check the selected plug-ins in your launch configuration (in *Plug-ins* tab)and remove any OS-specific agent bundle that does not fit
+   * Check the selected plug-ins in your launch configuration (in *Plug-ins* tab) and remove any OS-specific agent bundle that does not fit
      to your OS and remove all test bundles from the selected plug-ins from your Eclipse workspace.
    * Validate your config and ensure that all dependencies are resolved.
      Try *Select Required* button if something is missing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ When you submit a pull request, a CLA bot will automatically determine whether y
 - **Maven 3.8+** (or use the provided Maven wrapper `./mvnw`)
 - **Node.js 22.13** or later, with npm
 - **Eclipse IDE for Eclipse Committers 2024-03** or later (for development)
+- Recommended: **Eclipse Checkstyle plugin** for code style compliance
+  (e.g. install from update site: https://checkstyle.org/eclipse-cs-update-site/)
 
 ### Building the Project
 
@@ -53,7 +55,26 @@ The installable P2 repository is generated in `com.microsoft.copilot.eclipse.rep
 ### Running in Eclipse
 
 1. Import all modules into your Eclipse workspace.
-2. Use the launch configurations in the `launch/` directory.
+   * Select *File > Import... > General > Existing projects into Workspace*,
+     select the root directory of the copilot-for-eclipse git repo,
+     activate the check box *Search for nested projects*, and finish the wizard.
+   * Do import additional projects using the import wizard for Maven project (without a `.project` file):
+     Select *File > Import... > Maven > Existing Maven Projects*,
+   * Do also import the agent bundle for your OS (e.g., `com.microsoft.copilot.eclipse.core.agent.win-x64`)
+     after building the project with npm and maven or import all OS-specific agent bundles.
+2. Activate one of the target platforms, i.e. open one of the target definition files and select `Set As Active Target Platform`.
+   * target-terminal.target (Eclipse 4.37+)
+   * target-tm-terminal.target (Eclipse 4.36 and earlier)
+3. For using the Checkstyle configuration (assuming you have installed the Eclipse Checkstyle plugin, see prerequisites),
+   add a new named Checkstyle configuration.
+   * Select *Window > Preferences > Checkstyle* and press the *New...* button.
+   * Select Type="Project Relative Configuration", **name="copilot4eclipse"**, and choose the location using the *Browse...* button.
+     The `checkstyle.xml` file is in the git repository root folder in the project "github-copilot-for-eclipse".
+4. Use the launch configurations in the `launch/` directory, e.g. for launching a new Eclipse IDE with Copilot plug-ins.
+   * Check the selected plug-ins in your launch configuration (in *Plug-ins* tab)and remove any OS-specific agent bundle that does not fit
+     to your OS and remove all test bundles from the selected plug-ins from your Eclipse workspace.
+   * Validate your config and ensure that all dependencies are resolved.
+     Try *Select Required* button if something is missing.
 
 ## How to Contribute
 

--- a/com.microsoft.copilot.eclipse.branding/.project
+++ b/com.microsoft.copilot.eclipse.branding/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.branding</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.branding/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.branding/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.core.agent.linux.aarch64/.project
+++ b/com.microsoft.copilot.eclipse.core.agent.linux.aarch64/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.core.agent.linux.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.core.agent.linux.aarch64/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.core.agent.linux.aarch64/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.core.agent.linux.x64/.project
+++ b/com.microsoft.copilot.eclipse.core.agent.linux.x64/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.core.agent.linux.x64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.core.agent.linux.x64/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.core.agent.linux.x64/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.core.agent.macosx.aarch64/.project
+++ b/com.microsoft.copilot.eclipse.core.agent.macosx.aarch64/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.core.agent.macosx.aarch64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.core.agent.macosx.aarch64/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.core.agent.macosx.aarch64/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.core.agent.macosx.x64/.project
+++ b/com.microsoft.copilot.eclipse.core.agent.macosx.x64/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.core.agent.macosx.x64</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.core.agent.macosx.x64/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.core.agent.macosx.x64/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.core.agent.win32/.project
+++ b/com.microsoft.copilot.eclipse.core.agent.win32/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.core.agent.win32</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.core.agent.win32/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.core.agent.win32/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.feature/.project
+++ b/com.microsoft.copilot.eclipse.feature/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.repository/.project
+++ b/com.microsoft.copilot.eclipse.repository/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.microsoft.copilot.eclipse.repository</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.microsoft.copilot.eclipse.repository/.settings/org.eclipse.m2e.core.prefs
+++ b/com.microsoft.copilot.eclipse.repository/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.microsoft.copilot.eclipse.terminal.api/.classpath
+++ b/com.microsoft.copilot.eclipse.terminal.api/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.microsoft.copilot.eclipse.ui.jobs/.classpath
+++ b/com.microsoft.copilot.eclipse.ui.jobs/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.microsoft.copilot.eclipse.ui.terminal.tm/.classpath
+++ b/com.microsoft.copilot.eclipse.ui.terminal.tm/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.microsoft.copilot.eclipse.ui.terminal/.classpath
+++ b/com.microsoft.copilot.eclipse.ui.terminal/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>
 


### PR DESCRIPTION
This PR
- explains in more details how to start contributing, e.g. how to import Eclipse projects and how to launch the plug-ins
- adds `.project` files and Eclipse settings to simplify Eclipse project import for new developers
- Explains how to configure the Checkstyle Eclipse plug-in to work with this git repo