### PR TITLE
fix - UI freeze caused by deadlock in EditorsManager

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorsManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorsManager.java
@@ -162,8 +162,21 @@ public class EditorsManager {
       return null;
     }
 
-    return nesRenderManagers.computeIfAbsent(editor,
-        ed -> new RenderManager(this.languageServer, this.nesProvider, ed));
+    // Avoid computeIfAbsent() here: the RenderManager constructor calls
+    // Display.syncExec() via registerListeners(), and computeIfAbsent() holds
+    // an internal bucket lock during the mapping function. If the UI thread
+    // concurrently calls remove() on the same bucket, both threads deadlock.
+    // See https://github.com/microsoft/copilot-for-eclipse/issues/175
+    RenderManager mgr = nesRenderManagers.get(editor);
+    if (mgr == null) {
+      mgr = new RenderManager(this.languageServer, this.nesProvider, editor);
+      RenderManager existing = nesRenderManagers.putIfAbsent(editor, mgr);
+      if (existing != null) {
+        mgr.dispose();
+        mgr = existing;
+      }
+    }
+    return mgr;
   }
 
   /**


### PR DESCRIPTION
fix https://github.com/microsoft/copilot-for-eclipse/issues/175

## Problem

The UI freezes on startup when a user closes an editor tab while Copilot is still initializing.

**Deadlock chain:**
1. Worker thread calls `getOrCreateNesRenderManager()` → `ConcurrentHashMap.computeIfAbsent()` holds an internal bucket lock → inside the lambda, `new RenderManager()` → `registerListeners()` → `Display.syncExec()` blocks waiting for UI thread
2. UI thread handles editor close → `disposeNesRenderManager()` → `ConcurrentHashMap.remove()` blocks waiting for the same bucket lock

Both threads wait on each other indefinitely → permanent UI freeze.

## Fix

Replace `computeIfAbsent()` with `get()` + `putIfAbsent()` so that the `RenderManager` construction (which calls `syncExec`) happens outside of any map lock. If two threads race to create a manager for the same editor, the loser disposes its instance and uses the winner's.