### PR TITLE
fix - revert splitDropdownButton padding change

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/SplitDropdownButton.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/SplitDropdownButton.java
@@ -185,7 +185,7 @@ public class SplitDropdownButton {
   private void updatePadding() {
     String text = getText();
     String currentPadding = padding;
-    String newPadding = showArrow ? calculatePadding(25) : null;
+    String newPadding = showArrow ? calculatePadding(22) : null;
     if ((newPadding == null && currentPadding != null) || (newPadding != null && !newPadding.equals(currentPadding))) {
       this.padding = newPadding;
       setText(text);


### PR DESCRIPTION
fix https://github.com/microsoft/copilot-for-eclipse/issues/181

During the Terminal Auto-approve feature implementation (#171), I reused the SplitDropdownButton (originally from MCP Registry) and modified the arrow padding from 22 to 25. This change causes layout issues on macOS.

This PR reverts the padding value back to the original 22 to fix the macOS rendering issue.


cc @jdneo Could you help verify whether this ui issue is resolved on macOS? Thanks!