### PR TITLE
Add explicit least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    # `Update dependency graph` step uses maven-dependency-submission-action,
-    # which posts to the Dependency submission API and requires `contents: write`.
-    permissions:
-      contents: write
 
     steps:
     - uses: actions/checkout@v4
@@ -45,8 +41,3 @@ jobs:
       with:
        run: >-
            ./mvnw clean verify --batch-mode
-
-    # Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
-      continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -13,6 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    # `Update dependency graph` step uses maven-dependency-submission-action,
+    # which posts to the Dependency submission API and requires `contents: write`.
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds explicit `permissions:` declarations to `.github/workflows/ci.yml`:

- workflow-level default: `contents: read`
- per-job override on `build`: `contents: write`

## Why

`ci.yml` currently does not declare any `permissions:` block, so `GITHUB_TOKEN` inherits the repository default token scope. The recommended hardening pattern from GitHub is to declare the minimum scope at the workflow level and override per-job only where a higher scope is actually needed.

In this workflow:

- Most steps (`checkout`, `setup-node`, `npm i`, `setup-java`, maven build) only need `contents: read`.
- The `Update dependency graph` step uses [`advanced-security/maven-dependency-submission-action`](https://github.com/advanced-security/maven-dependency-submission-action), which calls the [Dependency submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission). That endpoint requires `contents: write`.

So the workflow-level default is `contents: read` and the `build` job overrides to `contents: write` to keep the dependency-graph upload working. Net effect: the security boundary is documented explicitly, and any future job added at the workflow level inherits the minimum scope by default.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- Existing behavior preserved: `Update dependency graph` step keeps the `contents: write` scope it implicitly relied on via the repo default.

## Reference

- [GitHub docs — Modifying the permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
- [advanced-security/maven-dependency-submission-action README](https://github.com/advanced-security/maven-dependency-submission-action#permissions)