### PR TITLE
[TBB] Thinking block UI improvements: Label title, collapse timing, height cap, and section parsing fix

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlockParseTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlockParseTest.java
@@ -62,6 +62,49 @@ class ThinkingBlockParseTest {
     assertEquals("plan body", body(sections.get(1)));
   }
 
+  @Test
+  void parseSections_inlineBoldNotTreatedAsTitle() throws Exception {
+    // Inline bold at end of string should NOT be parsed as a section title.
+    String raw = "combined with **The Ship of Theseus**";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(1, sections.size());
+    assertNull(title(sections.get(0)));
+    assertEquals("combined with **The Ship of Theseus**", body(sections.get(0)));
+  }
+
+  @Test
+  void parseSections_inlineBoldFollowedByText() throws Exception {
+    // Inline bold mid-line should remain as body text.
+    String raw = "text with **bold** and more text";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(1, sections.size());
+    assertNull(title(sections.get(0)));
+    assertEquals("text with **bold** and more text", body(sections.get(0)));
+  }
+
+  @Test
+  void parseSections_mixOfInlineBoldAndStandaloneTitle() throws Exception {
+    // Inline bold on one line, standalone title on next line.
+    String raw = "text with **inline bold** here\n**Standalone Title**\nbody after title";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(2, sections.size());
+    assertNull(title(sections.get(0)));
+    assertEquals("text with **inline bold** here", body(sections.get(0)));
+    assertEquals("Standalone Title", title(sections.get(1)));
+    assertEquals("body after title", body(sections.get(1)));
+  }
+
+  @Test
+  void parseSections_titleAtStartOfText() throws Exception {
+    String raw = "**First**\nbody one\n**Second**\nbody two";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(2, sections.size());
+    assertEquals("First", title(sections.get(0)));
+    assertEquals("body one", body(sections.get(0)));
+    assertEquals("Second", title(sections.get(1)));
+    assertEquals("body two", body(sections.get(1)));
+  }
+
   private static String invokeStripTrailingNewlines(String input) throws Exception {
     Method m = ThinkingBlock.class.getDeclaredMethod("stripTrailingNewlines", String.class);
     m.setAccessible(true);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -34,7 +34,8 @@ import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
  */
 public class ThinkingBlock extends Composite {
   private static final String SECONDARY_TEXT_CSS_CLASS = "text-secondary";
-  private static final Pattern TITLE_PATTERN = Pattern.compile("\\*\\*([^*\\r\\n]+?)\\*\\*(?=\\r?\\n|$)");
+  private static final Pattern TITLE_PATTERN =
+      Pattern.compile("(?:^|\\n)\\*\\*([^*\\r\\n]+?)\\*\\*(?=\\r?\\n|$)");
 
   private Composite header;
   private Label iconLabel;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Cursor;
@@ -37,16 +38,22 @@ public class ThinkingBlock extends Composite {
   private static final Pattern TITLE_PATTERN =
       Pattern.compile("(?:^|\\n)\\*\\*([^*\\r\\n]+?)\\*\\*(?=\\r?\\n|$)");
 
+  private static final int STREAMING_MAX_HEIGHT = 180;
+
   private Composite header;
   private Label iconLabel;
   private Label titleLabel;
   private Label chevronLabel;
 
-  /** Body container holding one {@link ThinkingSection} per parsed section. Hidden when collapsed. */
+  /** Scrollable wrapper around {@link #body}; used only during streaming. Disposed on finalized expand. */
+  private ScrolledComposite bodyScroller;
+  /** Body container holding one {@link ThinkingSection} per parsed section. */
   private Composite body;
   private final List<ThinkingSection> sections = new ArrayList<>();
   private final StringBuilder textBuffer = new StringBuilder();
   private boolean expanded = true;
+  /** Auto-scroll to bottom during streaming. Turned off on any user scroll interaction. */
+  private boolean autoScroll = true;
 
   /**
    * Lifecycle of the block. Transitions are always forward: STREAMING → (SEALED →)? → COMPLETED|CANCELLED.
@@ -123,6 +130,7 @@ public class ThinkingBlock extends Composite {
     }
     setTitleText(Messages.thinking_cancelledTitle);
     setExpanded(false);
+    unwrapBodyFromScroller();
     state = State.CANCELLED;
   }
 
@@ -139,6 +147,7 @@ public class ThinkingBlock extends Composite {
     stopSpinner();
     setTitleText(Messages.thinking_completedTitle);
     setExpanded(false);
+    unwrapBodyFromScroller();
   }
 
   /** True only while new thinking stream fragments should still be appended to this block. */
@@ -226,14 +235,26 @@ public class ThinkingBlock extends Composite {
   }
 
   private void createBody() {
-    body = new Composite(this, SWT.NONE);
+    bodyScroller = new ScrolledComposite(this, SWT.V_SCROLL);
+    bodyScroller.setExpandHorizontal(true);
+    bodyScroller.setExpandVertical(true);
+    bodyScroller.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+    bodyScroller.setAlwaysShowScrollBars(false);
+
+    body = new Composite(bodyScroller, SWT.NONE);
     GridLayout bodyLayout = new GridLayout(1, false);
     bodyLayout.marginHeight = 4;
     bodyLayout.marginLeft = 4;
     bodyLayout.marginWidth = 0;
     bodyLayout.verticalSpacing = 6;
     body.setLayout(bodyLayout);
-    body.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+
+    bodyScroller.setContent(body);
+
+    // Any user scroll interaction disables auto-scroll unconditionally.
+    Runnable disableAutoScroll = () -> autoScroll = false;
+    bodyScroller.getVerticalBar().addListener(SWT.Selection, e -> disableAutoScroll.run());
+    body.addListener(SWT.MouseVerticalWheel, e -> disableAutoScroll.run());
   }
 
   /** Parsed (title?, body) tuple. */
@@ -270,7 +291,39 @@ public class ThinkingBlock extends Composite {
     }
 
     body.requestLayout();
+    updateScrollerDuringStreaming();
     refreshEnclosingScroller();
+  }
+
+  /** Resize the scroller to fit content (up to max height) and auto-scroll to bottom if enabled. */
+  private void updateScrollerDuringStreaming() {
+    if (bodyScroller == null || bodyScroller.isDisposed()) {
+      return;
+    }
+    int contentWidth = bodyScroller.getClientArea().width;
+    if (contentWidth <= 0) {
+      contentWidth = SWT.DEFAULT;
+    }
+    int contentHeight = body.computeSize(contentWidth, SWT.DEFAULT).y;
+    bodyScroller.setMinSize(body.computeSize(contentWidth, SWT.DEFAULT));
+
+    // Grow with content up to max; avoids blank space when content is small.
+    GridData scrollerData = (GridData) bodyScroller.getLayoutData();
+    int newHint = Math.min(contentHeight, STREAMING_MAX_HEIGHT);
+    if (scrollerData.heightHint != newHint) {
+      scrollerData.heightHint = newHint;
+    }
+
+    if (state == State.STREAMING && autoScroll) {
+      bodyScroller.setOrigin(0, contentHeight);
+    } else if (state == State.STREAMING && !autoScroll) {
+      // Re-enable auto-scroll if user scrolled back to the bottom.
+      int scrollPos = bodyScroller.getOrigin().y;
+      int viewportHeight = bodyScroller.getClientArea().height;
+      if (scrollPos + viewportHeight >= contentHeight - 10) {
+        autoScroll = true;
+      }
+    }
   }
 
   /**
@@ -361,15 +414,33 @@ public class ThinkingBlock extends Composite {
 
   private void setExpanded(boolean newExpanded) {
     this.expanded = newExpanded;
-    if (body != null && !body.isDisposed()) {
-      GridData data = (GridData) body.getLayoutData();
+
+    Composite bodyContainer = bodyScroller != null ? bodyScroller : body;
+    if (bodyContainer != null && !bodyContainer.isDisposed()) {
+      GridData data = (GridData) bodyContainer.getLayoutData();
       data.exclude = !expanded;
-      body.setVisible(expanded);
+      bodyContainer.setVisible(expanded);
     }
     updateChevron();
     requestLayout();
     // Refresh the enclosing scroller so the revealed/hidden body height is reachable.
     refreshEnclosingScroller();
+  }
+
+  /** Move body from ScrolledComposite to be a direct child of this block. */
+  private void unwrapBodyFromScroller() {
+    if (bodyScroller == null || bodyScroller.isDisposed() || body == null || body.isDisposed()) {
+      return;
+    }
+    bodyScroller.setContent(null);
+    body.setParent(this);
+    GridData bodyData = new GridData(SWT.FILL, SWT.FILL, true, false);
+    bodyData.exclude = !expanded;
+    body.setLayoutData(bodyData);
+    body.setVisible(expanded);
+    body.moveBelow(bodyScroller);
+    bodyScroller.dispose();
+    bodyScroller = null;
   }
 
   private void updateChevron() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -93,7 +93,7 @@ public class ThinkingBlock extends Composite {
     requestLayout();
   }
 
-  /** Hide the icon, set the title, and collapse. No-op if already finalized. Spinner was already stopped at SEALED. */
+  /** Update the title and finalize as completed. Block was already collapsed at seal time. */
   public void showCompleted(String title) {
     if (isFinalized()) {
       return;
@@ -105,7 +105,6 @@ public class ThinkingBlock extends Composite {
       iconLabel.requestLayout();
     }
     setTitleText(title);
-    setExpanded(false);
     state = State.COMPLETED;
   }
 
@@ -138,6 +137,7 @@ public class ThinkingBlock extends Composite {
     state = State.SEALED;
     stopSpinner();
     setTitleText(Messages.thinking_completedTitle);
+    setExpanded(false);
   }
 
   /** True only while new thinking stream fragments should still be appended to this block. */

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -12,7 +12,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Cursor;
@@ -23,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 
+import com.microsoft.copilot.eclipse.ui.CopilotUi;
 import com.microsoft.copilot.eclipse.ui.swt.SpinnerAnimator;
 import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
 
@@ -37,9 +37,8 @@ public class ThinkingBlock extends Composite {
   private static final Pattern TITLE_PATTERN = Pattern.compile("\\*\\*([^*\\r\\n]+?)\\*\\*(?=\\r?\\n|$)");
 
   private Composite header;
-  private GridLayout headerLayout;
   private Label iconLabel;
-  private ChatMarkupViewer titleViewer;
+  private Label titleLabel;
   private Label chevronLabel;
 
   /** Body container holding one {@link ThinkingSection} per parsed section. Hidden when collapsed. */
@@ -174,7 +173,7 @@ public class ThinkingBlock extends Composite {
 
   private void createHeader() {
     header = new Composite(this, SWT.NONE);
-    headerLayout = new GridLayout(4, false);
+    GridLayout headerLayout = new GridLayout(4, false);
     headerLayout.marginHeight = 0;
     headerLayout.marginWidth = 0;
     // Match AgentStatusLabel's icon-to-text spacing for visual consistency.
@@ -185,16 +184,14 @@ public class ThinkingBlock extends Composite {
     iconLabel = new Label(header, SWT.NONE);
     iconLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 
-    // Title: no grab so the chevron can sit immediately after it; widthHint is recomputed on
-    // resize so SWT.WRAP kicks in when the title would otherwise overflow.
-    titleViewer = new ChatMarkupViewer(header, SWT.LEFT | SWT.WRAP);
-    StyledText titleText = titleViewer.getTextWidget();
-    GridData titleData = new GridData(SWT.LEFT, SWT.CENTER, false, false);
-    titleText.setLayoutData(titleData);
-    titleText.setEditable(false);
-    // Strip StyledText's intrinsic margins so the text sits flush with the adjacent labels.
-    titleText.setMargins(0, 0, 0, 0);
-    UiUtils.applyCssClass(titleText, SECONDARY_TEXT_CSS_CLASS, stylingEngine);
+    titleLabel = new Label(header, SWT.LEFT | SWT.WRAP);
+    titleLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+    UiUtils.applyCssClass(titleLabel, SECONDARY_TEXT_CSS_CLASS, stylingEngine);
+
+    var chatServiceManager = CopilotUi.getPlugin().getChatServiceManager();
+    if (chatServiceManager != null) {
+      chatServiceManager.getChatFontService().registerControl(titleLabel);
+    }
 
     chevronLabel = new Label(header, SWT.NONE);
     chevronLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
@@ -205,11 +202,11 @@ public class ThinkingBlock extends Composite {
 
     Cursor handCursor = getDisplay().getSystemCursor(SWT.CURSOR_HAND);
     header.setCursor(handCursor);
-    titleText.setCursor(handCursor);
+    titleLabel.setCursor(handCursor);
     chevronLabel.setCursor(handCursor);
 
-    // Constrain the title's width so SWT.WRAP can take effect once the parent is narrower than
-    // the natural single-line width of the markup.
+    // Constrain the title's width so SWT.WRAP can take effect when the header is narrower than
+    // the natural single-line width of the title.
     header.addListener(SWT.Resize, e -> updateTitleWidthHint());
 
     MouseAdapter toggleListener = new MouseAdapter() {
@@ -222,7 +219,7 @@ public class ThinkingBlock extends Composite {
     // cursor is actually clickable. iconLabel is intentionally excluded: it hosts the live spinner
     // animation (and the cancel icon afterwards), and a clickable spinner is an odd affordance.
     header.addMouseListener(toggleListener);
-    titleText.addMouseListener(toggleListener);
+    titleLabel.addMouseListener(toggleListener);
     chevronLabel.addMouseListener(toggleListener);
     filler.addMouseListener(toggleListener);
   }
@@ -322,38 +319,34 @@ public class ThinkingBlock extends Composite {
   }
 
   private void setTitleText(String text) {
-    if (titleViewer == null || titleViewer.getTextWidget().isDisposed()) {
+    if (titleLabel == null || titleLabel.isDisposed()) {
       return;
     }
-    titleViewer.setMarkup(text == null ? "" : text);
+    titleLabel.setText(text == null ? "" : text);
     updateTitleWidthHint();
-    titleViewer.getTextWidget().requestLayout();
+    titleLabel.requestLayout();
   }
 
   private void updateTitleWidthHint() {
-    if (titleViewer == null || header == null || header.isDisposed()) {
-      return;
-    }
-    StyledText titleText = titleViewer.getTextWidget();
-    if (titleText.isDisposed()) {
+    if (titleLabel == null || titleLabel.isDisposed() || header == null || header.isDisposed()) {
       return;
     }
     int headerWidth = header.getClientArea().width;
     if (headerWidth <= 0) {
       return;
     }
-    int iconWidth = iconLabel != null && !iconLabel.isDisposed() ? iconLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).x
-        : 0;
+    GridLayout layout = (GridLayout) header.getLayout();
+    int iconWidth = iconLabel != null && !iconLabel.isDisposed() && iconLabel.isVisible()
+        ? iconLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).x : 0;
     int chevronWidth = chevronLabel != null && !chevronLabel.isDisposed()
-        ? chevronLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).x
-        : 0;
-    int spacing = headerLayout.horizontalSpacing * (headerLayout.numColumns - 1);
-    int available = headerWidth - iconWidth - chevronWidth - spacing - headerLayout.marginWidth * 2;
+        ? chevronLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).x : 0;
+    int spacing = layout.horizontalSpacing * (layout.numColumns - 1);
+    int available = headerWidth - iconWidth - chevronWidth - spacing - layout.marginWidth * 2;
     if (available <= 0) {
       return;
     }
-    GridData titleData = (GridData) titleText.getLayoutData();
-    int natural = titleText.computeSize(SWT.DEFAULT, SWT.DEFAULT).x;
+    GridData titleData = (GridData) titleLabel.getLayoutData();
+    int natural = titleLabel.computeSize(SWT.DEFAULT, SWT.DEFAULT).x;
     int newHint = Math.min(natural, available);
     if (newHint != titleData.widthHint) {
       titleData.widthHint = newHint;
@@ -400,8 +393,8 @@ public class ThinkingBlock extends Composite {
     header.setToolTipText(tooltip);
     chevronLabel.setImage(image);
     chevronLabel.setToolTipText(tooltip);
-    if (titleViewer != null && !titleViewer.getTextWidget().isDisposed()) {
-      titleViewer.getTextWidget().setToolTipText(tooltip);
+    if (titleLabel != null && !titleLabel.isDisposed()) {
+      titleLabel.setToolTipText(tooltip);
     }
   }
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 
 import com.microsoft.copilot.eclipse.ui.CopilotUi;
+import com.microsoft.copilot.eclipse.ui.chat.services.ChatServiceManager;
 import com.microsoft.copilot.eclipse.ui.swt.SpinnerAnimator;
 import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
 
@@ -198,7 +199,7 @@ public class ThinkingBlock extends Composite {
     titleLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
     UiUtils.applyCssClass(titleLabel, SECONDARY_TEXT_CSS_CLASS, stylingEngine);
 
-    var chatServiceManager = CopilotUi.getPlugin().getChatServiceManager();
+    ChatServiceManager chatServiceManager = CopilotUi.getPlugin().getChatServiceManager();
     if (chatServiceManager != null) {
       chatServiceManager.getChatFontService().registerControl(titleLabel);
     }
@@ -305,7 +306,7 @@ public class ThinkingBlock extends Composite {
       contentWidth = SWT.DEFAULT;
     }
     int contentHeight = body.computeSize(contentWidth, SWT.DEFAULT).y;
-    bodyScroller.setMinSize(body.computeSize(contentWidth, SWT.DEFAULT));
+    bodyScroller.setMinSize(contentWidth, contentHeight);
 
     // Grow with content up to max; avoids blank space when content is small.
     GridData scrollerData = (GridData) bodyScroller.getLayoutData();
@@ -438,7 +439,6 @@ public class ThinkingBlock extends Composite {
     bodyData.exclude = !expanded;
     body.setLayoutData(bodyData);
     body.setVisible(expanded);
-    body.moveBelow(bodyScroller);
     bodyScroller.dispose();
     bodyScroller = null;
   }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -82,7 +82,7 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
     }
     CopilotLanguageServerConnection ls = CopilotCore.getPlugin().getCopilotLanguageServer();
     if (ls == null) {
-      target.showCancelled();
+      target.showCompleted(Messages.thinking_completedTitle);
       requestLayout();
       return;
     }
@@ -100,11 +100,19 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
           if (resp != null && StringUtils.isNotBlank(resp.title())) {
             target.showCompleted(resp.title());
           } else {
-            // Title fetch failed: surface the cancelled visual state so the spinner does not run forever.
-            target.showCancelled();
+            target.showCompleted(Messages.thinking_completedTitle);
           }
           requestLayout();
-        }, this));
+        }, this))
+        .exceptionally(ex -> {
+          SwtUtils.invokeOnDisplayThreadAsync(() -> {
+            if (!isDisposed() && !target.isDisposed() && !target.isFinalized()) {
+              target.showCompleted(Messages.thinking_completedTitle);
+              requestLayout();
+            }
+          }, this);
+          return null;
+        });
   }
 
   @Override

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -82,6 +82,7 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
     }
     CopilotLanguageServerConnection ls = CopilotCore.getPlugin().getCopilotLanguageServer();
     if (ls == null) {
+      target.markSealed();
       target.showCompleted(Messages.thinking_completedTitle);
       requestLayout();
       return;


### PR DESCRIPTION
## Changes

### Use Label instead of ChatMarkupViewer for thinking block header title
- Replace `ChatMarkupViewer` with a lightweight SWT `Label` for the ThinkingBlock header title ("Thinking...", "Thinking completed", etc.)
- The header title is plain text with no markdown formatting, so `ChatMarkupViewer` (which initializes a full Markdown parser, hyperlink detectors, and CSS stylesheets) is unnecessary overhead
- Register the Label with `ChatFontService` to keep chat font synchronization
- Add `SWT.WRAP` and `updateTitleWidthHint()` to handle long titles correctly on resize

<img width="865" height="422" alt="image" src="https://github.com/user-attachments/assets/3db82949-cbcd-420a-9ee8-8a58021d3a1f" />

Resolves #178

### Fix title generation fallback showing "cancelled" instead of "completed"
- When `thinking/generateTitle` returns empty or fails, the thinking block previously showed "Thinking cancelled" — but the thinking itself completed successfully, only the title generation failed
- Changed fallback to `showCompleted("Thinking completed")` instead of `showCancelled()`
- Added `.exceptionally()` handler to catch request errors, preventing the block from getting stuck in SEALED state

Before: 
<img width="945" height="264" alt="image" src="https://github.com/user-attachments/assets/3c3c747a-7f97-4a6a-a91e-914f909a35e2" />

After:
<img width="1084" height="305" alt="image" src="https://github.com/user-attachments/assets/6c7ad967-4ad2-4b4a-938e-e3e8c0b6a29c" />

### Collapse thinking block immediately when thinking ends
Previously, the thinking block stayed expanded until the thinking title generation response arrived, which could take several seconds. During this gap the block showed "Thinking completed" but remained open, which felt unresponsive.

Now the block collapses as soon as thinking output stops.

### Cap thinking body height during streaming with auto-scroll
During streaming, the thinking block body is now wrapped in a ScrolledComposite with a max height of 180px. This prevents long thinking output from pushing the chat view unboundedly downward.

- Body height grows dynamically with content up to the cap, avoiding initial blank space
- Auto-scrolls to bottom as new content arrives
- User can scroll up to read earlier content; any scroll interaction disables auto-scroll
- Auto-scroll re-enables when the user scrolls back to the bottom
- On seal/cancel, the ScrolledComposite is unwrapped and body becomes a direct child, so post-finalization expand shows full content without scrollbar or scroll-wheel interception
<img width="1212" height="398" alt="image" src="https://github.com/user-attachments/assets/6732de27-61b3-452a-ac94-9f5cc790fcad" />

### Fix ghost section from inline bold at streaming fragment boundary
Fixed a bug where inline bold text (e.g. combined with **The Ship of Theseus** and its...) could appear as a spurious section title with a bullet point at the end of the thinking block.
<img width="1611" height="1133" alt="image" src="https://github.com/user-attachments/assets/52a780dc-6901-4807-a88a-f7fbb0632a36" />

Root cause: TITLE_PATTERN required **Title** to be followed by \n or end-of-string ($), but did not require it to be at the start of a line. When a streaming fragment happened to end right after **The Ship of Theseus**, the $ anchor matched the buffer end, creating a ghost ThinkingSection. Subsequent fragments appended more text, making the match disappear — but the widget was never cleaned up.

Fix: Added (?:^|\n) anchor to require **Title** to appear at line start or string start. Added unit tests covering inline bold, mixed inline+standalone, and title-at-start scenarios.
