### PR TITLE
refactor: [TBB] extract ItemController for dropdown popup item rows (Thinking Effort Part1)

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/DropdownPopup.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/DropdownPopup.java
@@ -14,7 +14,6 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseTrackAdapter;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -48,7 +47,6 @@ class DropdownPopup {
   private static final int ICON_TEXT_GAP = 6;
   private static final int LABEL_SUFFIX_GAP = 12;
   private static final int BORDER_ARC = 8;
-  private static final int ITEM_FOCUS_ARC = 6;
   private static final int MAX_VISIBLE_ITEMS = 15;
   private static final int SHORT_POPUP_WIDTH = 230;
   private static final int LONG_POPUP_WIDTH = 300;
@@ -60,7 +58,7 @@ class DropdownPopup {
   private Consumer<String> selectionListener;
   private String selectedItemId;
 
-  private record ItemEntry(DropdownItem item, Composite composite) {}
+  private record ItemEntry(DropdownItem item, Composite composite, ItemController row) {}
 
   private final List<ItemEntry> items = new ArrayList<>();
   private int focusedIndex = -1;
@@ -71,13 +69,8 @@ class DropdownPopup {
   private final IStylingEngine stylingEngine;
   private final Control anchorControl;
 
-  private static final String POPUP_ITEM_DEFAULT_ID = "popup-item-default";
-  private static final String POPUP_ITEM_FOCUSED_ID = "popup-item-focused";
-  private static final String POPUP_ITEM_SELECTED_ID = "popup-item-selected";
   private static final String POPUP_SECONDARY_TEXT_CLASS = "popup-secondary-text";
   private static final String POPUP_ACTION_TEXT_CLASS = "popup-action-text";
-  private static final String POPUP_ITEM_BASE_ID_KEY = "dropdownPopupItemBaseId";
-  private static final String POPUP_ITEM_FOCUSED_KEY = "dropdownPopupItemFocused";
 
   DropdownPopup(Shell parentShell, Control anchorControl) {
     this.parentShell = parentShell;
@@ -305,10 +298,10 @@ class DropdownPopup {
     headerComp.setLayout(layout);
     Label headerLabel = new Label(headerComp, SWT.NONE);
     headerLabel.setText(text);
-    headerLabel.setData(CssConstants.CSS_ID_KEY, POPUP_ITEM_DEFAULT_ID);
+    headerLabel.setData(CssConstants.CSS_ID_KEY, ItemController.CSS_DEFAULT_ID);
     setCssClassOnly(headerLabel, POPUP_SECONDARY_TEXT_CLASS);
     headerLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-    applyCssIdRecursively(headerComp, POPUP_ITEM_DEFAULT_ID);
+    applyCssIdRecursively(headerComp, ItemController.CSS_DEFAULT_ID);
   }
 
   private void addSeparator(Composite parent) {
@@ -328,7 +321,7 @@ class DropdownPopup {
   private void addItem(Composite parent, DropdownItem item) {
     final Display display = parent.getDisplay();
     final boolean isSelected = item.getId() != null && item.getId().equals(selectedItemId);
-    final String itemBaseCssId = isSelected ? POPUP_ITEM_SELECTED_ID : POPUP_ITEM_DEFAULT_ID;
+    final String itemBaseCssId = isSelected ? ItemController.CSS_SELECTED_ID : ItemController.CSS_DEFAULT_ID;
 
     Composite itemComp = new Composite(parent, SWT.NONE);
     itemComp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
@@ -337,10 +330,8 @@ class DropdownPopup {
     itemLayout.marginHeight = ITEM_V_PADDING;
     itemLayout.horizontalSpacing = ICON_TEXT_GAP;
     itemComp.setLayout(itemLayout);
-    itemComp.addPaintListener(e -> paintFocusedItemBackground(itemComp, e.gc));
 
-    items.add(new ItemEntry(item, itemComp));
-    final int itemIndex = items.size() - 1;
+    final int itemIndex = items.size();
 
     List<Control> controls = new ArrayList<>();
     controls.add(itemComp);
@@ -381,7 +372,8 @@ class DropdownPopup {
     setCssClassOnly(suffixLabel, POPUP_SECONDARY_TEXT_CLASS);
     controls.add(suffixLabel);
 
-    setPopupItemState(itemComp, itemBaseCssId, false);
+    ItemController rowController = ItemController.attach(itemComp, stylingEngine, itemBaseCssId);
+    items.add(new ItemEntry(item, itemComp, rowController));
 
     String tooltip = item.getTooltip();
     MouseTrackAdapter hoverTracker = buildHoverTracker(item, itemComp, itemIndex);
@@ -575,18 +567,15 @@ class DropdownPopup {
     if (index < 0 || index >= items.size()) {
       return;
     }
-    Composite itemComp = items.get(index).composite();
-    if (!itemComp.isDisposed()) {
-      if (focused) {
-        String baseId = (String) itemComp.getData(POPUP_ITEM_BASE_ID_KEY);
-        setPopupItemState(itemComp, baseId != null ? baseId : POPUP_ITEM_DEFAULT_ID, true);
-      } else {
-        DropdownItem item = items.get(index).item();
-        String baseId = item.getId() != null && item.getId().equals(selectedItemId) ? POPUP_ITEM_SELECTED_ID
-            : POPUP_ITEM_DEFAULT_ID;
-        setPopupItemState(itemComp, baseId, false);
-      }
+    ItemEntry entry = items.get(index);
+    if (entry.composite().isDisposed()) {
+      return;
     }
+    String baseId = entry.item().getId() != null && entry.item().getId().equals(selectedItemId)
+        ? ItemController.CSS_SELECTED_ID
+        : ItemController.CSS_DEFAULT_ID;
+    entry.row().setBaseCssId(baseId);
+    entry.row().setFocused(focused);
   }
 
   private void activateFocusedItem() {
@@ -623,35 +612,6 @@ class DropdownPopup {
 
   boolean isOpen() {
     return shell != null && !shell.isDisposed() && shell.isVisible();
-  }
-
-  private void setPopupItemState(Composite control, String baseCssId, boolean focused) {
-    String currentBaseCssId = (String) control.getData(POPUP_ITEM_BASE_ID_KEY);
-    boolean currentFocused = Boolean.TRUE.equals(control.getData(POPUP_ITEM_FOCUSED_KEY));
-    if (focused == currentFocused && baseCssId.equals(currentBaseCssId)) {
-      return;
-    }
-    control.setData(POPUP_ITEM_BASE_ID_KEY, baseCssId);
-    control.setData(POPUP_ITEM_FOCUSED_KEY, focused);
-    control.setRedraw(false);
-    applyCssId(control, baseCssId);
-    for (Control child : control.getChildren()) {
-      applyCssIdRecursively(child, focused ? POPUP_ITEM_FOCUSED_ID : baseCssId);
-    }
-    control.setRedraw(true);
-  }
-
-  private void paintFocusedItemBackground(Composite itemComp, GC gc) {
-    if (!Boolean.TRUE.equals(itemComp.getData(POPUP_ITEM_FOCUSED_KEY))) {
-      return;
-    }
-    Rectangle bounds = itemComp.getClientArea();
-    if (bounds.width <= 0 || bounds.height <= 0) {
-      return;
-    }
-    gc.setAntialias(SWT.ON);
-    gc.setBackground(CssConstants.getPopupItemFocusBgColor(itemComp.getDisplay()));
-    gc.fillRoundRectangle(0, 0, bounds.width, bounds.height, ITEM_FOCUS_ARC, ITEM_FOCUS_ARC);
   }
 
   private void applyCssId(Control control, String cssId) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/ItemController.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/ItemController.java
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.copilot.eclipse.ui.swt;
+
+import org.eclipse.e4.ui.services.IStylingEngine;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+/**
+ * Controller that owns the focus / selection CSS state and the focused-background paint for a single popup item row.
+ *
+ * <p>Extracted from the inline state previously kept on the row composite via {@code Control.setData(...)} slots so
+ * other popup rows (e.g. future inline action rows inside hover content) can reuse the exact same selection and focus
+ * presentation without duplicating the CSS-id propagation and paint logic.
+ *
+ * <p>A controller is attached to a row composite via {@link #attach(Composite, IStylingEngine, String)}. It then:
+ * <ul>
+ *   <li>tracks a <em>base</em> CSS id ({@link #CSS_DEFAULT_ID} or {@link #CSS_SELECTED_ID}) reflecting whether the row
+ *       represents the currently selected entry,</li>
+ *   <li>tracks a <em>focused</em> flag indicating whether the row is currently highlighted (mouse hover or keyboard
+ *       focus),</li>
+ *   <li>propagates the resulting CSS id to every descendant control so the focused background paints behind child
+ *       labels,</li>
+ *   <li>paints a rounded background fill on the row while focused.</li>
+ * </ul>
+ */
+public final class ItemController {
+
+  /** CSS id applied to a default (non-selected, non-focused) popup item row and its descendants. */
+  public static final String CSS_DEFAULT_ID = "popup-item-default";
+
+  /** CSS id applied to the popup item row that represents the currently selected entry. */
+  public static final String CSS_SELECTED_ID = "popup-item-selected";
+
+  /** CSS id applied to descendants of a popup item row that is currently highlighted. */
+  public static final String CSS_FOCUSED_ID = "popup-item-focused";
+
+  /** Corner radius of the rounded background fill painted on focused popup item rows. */
+  public static final int FOCUS_ARC = 6;
+
+  private final Composite row;
+  private final IStylingEngine styling;
+  private String baseCssId;
+  private boolean focused;
+
+  private ItemController(Composite row, IStylingEngine styling, String baseCssId) {
+    this.row = row;
+    this.styling = styling;
+    this.baseCssId = baseCssId;
+  }
+
+  /**
+   * Attaches a controller to {@code row}: installs the focused-background paint listener and seeds the initial
+   * (non-focused) CSS state on the row and every existing descendant.
+   *
+   * @param row the row composite to manage; children should already be created so the initial CSS state propagates
+   *     to them
+   * @param styling the workbench styling engine (may be {@code null} when CSS styling is unavailable)
+   * @param baseCssId the initial base CSS id (typically {@link #CSS_DEFAULT_ID} or {@link #CSS_SELECTED_ID})
+   * @return the attached controller
+   */
+  public static ItemController attach(Composite row, IStylingEngine styling, String baseCssId) {
+    ItemController controller = new ItemController(row, styling, baseCssId);
+    row.addPaintListener(e -> controller.paintFocusedBackground(e.gc));
+    controller.applyState();
+    return controller;
+  }
+
+  /**
+   * Updates the base CSS id (default vs. selected). No-op when unchanged.
+   *
+   * @param newBaseCssId the new base CSS id; ignored when {@code null}
+   */
+  public void setBaseCssId(String newBaseCssId) {
+    if (newBaseCssId == null || newBaseCssId.equals(this.baseCssId)) {
+      return;
+    }
+    this.baseCssId = newBaseCssId;
+    applyState();
+  }
+
+  /**
+   * Updates the focused flag. No-op when unchanged.
+   *
+   * @param newFocused whether the row should be rendered as focused
+   */
+  public void setFocused(boolean newFocused) {
+    if (newFocused == this.focused) {
+      return;
+    }
+    this.focused = newFocused;
+    applyState();
+  }
+
+  private void applyState() {
+    if (row.isDisposed() || baseCssId == null) {
+      return;
+    }
+    String descendantCssId = focused ? CSS_FOCUSED_ID : baseCssId;
+    row.setRedraw(false);
+    applyCssId(row, baseCssId);
+    for (Control child : row.getChildren()) {
+      applyCssIdRecursively(child, descendantCssId);
+    }
+    row.setRedraw(true);
+    row.redraw();
+  }
+
+  private void paintFocusedBackground(GC gc) {
+    if (row.isDisposed() || !focused) {
+      return;
+    }
+    Rectangle bounds = row.getClientArea();
+    if (bounds.width <= 0 || bounds.height <= 0) {
+      return;
+    }
+    gc.setAntialias(SWT.ON);
+    gc.setBackground(CssConstants.getPopupItemFocusBgColor(row.getDisplay()));
+    gc.fillRoundRectangle(0, 0, bounds.width, bounds.height, FOCUS_ARC, FOCUS_ARC);
+  }
+
+  private void applyCssId(Control control, String cssId) {
+    if (control.isDisposed()) {
+      return;
+    }
+    if (!cssId.equals(control.getData(CssConstants.CSS_ID_KEY))) {
+      control.setData(CssConstants.CSS_ID_KEY, cssId);
+      if (styling != null) {
+        styling.style(control);
+      }
+    }
+  }
+
+  private void applyCssIdRecursively(Control control, String cssId) {
+    applyCssId(control, cssId);
+    if (control instanceof Composite composite) {
+      for (Control child : composite.getChildren()) {
+        applyCssIdRecursively(child, cssId);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This removes the inline Control.setData(...) state slots and ad-hoc paint listener that were previously duplicated inside DropdownPopup, and gives future popup rows (e.g. thinking effort rows inside hover content) a single shared implementation to attach to.

No behavior changes for the existing model picker: the same CSS ids, focus arc, and focus background color are used; only the ownership of the state moves out of DropdownPopup.