### PR TITLE
feat-  Unify thinking block title under a single "Thinking" label and change cancel timing

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/Messages.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/Messages.java
@@ -40,9 +40,7 @@ public final class Messages extends NLS {
   public static String todoList_clearButtonDisabled;
   public static String todoList_expandTooltip;
   public static String todoList_collapseTooltip;
-  public static String thinking_inProgressTitle;
-  public static String thinking_completedTitle;
-  public static String thinking_cancelledTitle;
+  public static String thinking_title;
   public static String thinking_expandTooltip;
   public static String thinking_collapseTooltip;
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -116,9 +116,18 @@ public class ThinkingBlock extends Composite {
     state = State.COMPLETED;
   }
 
-  /** Swap to the cancel icon, set the cancelled title, and collapse. No-op if already finalized. */
+  /**
+   * Cancel the thinking block. If still streaming, shows the cancel icon and collapses. If already sealed (thinking
+   * content finished, title fetch in flight), simply finalizes as completed since thinking itself was not interrupted.
+   * No-op if already finalized.
+   */
   public void showCancelled() {
     if (isFinalized()) {
+      return;
+    }
+    if (state == State.SEALED) {
+      // Thinking content already finished; just finalize without the cancel icon.
+      showCompleted();
       return;
     }
     stopSpinner();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -135,7 +135,7 @@ public class ThinkingBlock extends Composite {
 
   /**
    * Mark the block as sealed: the owning widget has requested a title and any further thinking stream fragments must
-   * land in a new block. Stops the spinner and shows the intermediate "Thinking..." title while the title
+   * land in a new block. Stops the spinner and shows the intermediate "Thinking" title while the title
    * fetch is in flight. No-op once the block has been finalized or already sealed.
    */
   public void markSealed() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -135,8 +135,8 @@ public class ThinkingBlock extends Composite {
 
   /**
    * Mark the block as sealed: the owning widget has requested a title and any further thinking stream fragments must
-   * land in a new block. Stops the spinner and shows the intermediate "Thinking" title while the title
-   * fetch is in flight. No-op once the block has been finalized or already sealed.
+   * land in a new block. Stops the spinner and collapses the block while the owning widget handles any subsequent
+   * title updates. No-op once the block has been finalized or already sealed.
    */
   public void markSealed() {
     if (state != State.STREAMING) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -31,7 +31,7 @@ import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
 /**
  * Collapsible "Thinking" banner shown above an assistant turn while the model emits thinking stream.
  *
- * <p>Pure view: callers drive the visual state via {@link #showCompleted(String)} and {@link #showCancelled()}.
+ * <p>Pure view: callers drive the visual state via {@link #showCompleted()} and {@link #showCancelled()}.
  * The owning turn widget is responsible for cancellation events and title fetching.
  */
 public class ThinkingBlock extends Composite {
@@ -86,7 +86,7 @@ public class ThinkingBlock extends Composite {
 
     addDisposeListener(e -> handleDispose());
 
-    setTitleText(Messages.thinking_inProgressTitle);
+    setTitle(Messages.thinking_title);
     spinner = new SpinnerAnimator(iconLabel);
     spinner.start();
     updateChevron();
@@ -102,8 +102,8 @@ public class ThinkingBlock extends Composite {
     requestLayout();
   }
 
-  /** Update the title and finalize as completed. Block was already collapsed at seal time. */
-  public void showCompleted(String title) {
+  /** Finalize as completed: hide spinner icon and transition to COMPLETED state. */
+  public void showCompleted() {
     if (isFinalized()) {
       return;
     }
@@ -113,7 +113,6 @@ public class ThinkingBlock extends Composite {
       iconLabel.setVisible(false);
       iconLabel.requestLayout();
     }
-    setTitleText(title);
     state = State.COMPLETED;
   }
 
@@ -129,7 +128,6 @@ public class ThinkingBlock extends Composite {
     if (!iconLabel.isDisposed()) {
       iconLabel.setImage(cancelledIcon);
     }
-    setTitleText(Messages.thinking_cancelledTitle);
     setExpanded(false);
     unwrapBodyFromScroller();
     state = State.CANCELLED;
@@ -137,7 +135,7 @@ public class ThinkingBlock extends Composite {
 
   /**
    * Mark the block as sealed: the owning widget has requested a title and any further thinking stream fragments must
-   * land in a new block. Stops the spinner and shows the intermediate "Thinking completed" title while the title
+   * land in a new block. Stops the spinner and shows the intermediate "Thinking..." title while the title
    * fetch is in flight. No-op once the block has been finalized or already sealed.
    */
   public void markSealed() {
@@ -146,7 +144,6 @@ public class ThinkingBlock extends Composite {
     }
     state = State.SEALED;
     stopSpinner();
-    setTitleText(Messages.thinking_completedTitle);
     setExpanded(false);
     unwrapBodyFromScroller();
   }
@@ -373,7 +370,8 @@ public class ThinkingBlock extends Composite {
     return s.substring(0, end);
   }
 
-  private void setTitleText(String text) {
+  /** Update the header title text. */
+  public void setTitle(String text) {
     if (titleLabel == null || titleLabel.isDisposed()) {
       return;
     }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -83,7 +83,7 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
     CopilotLanguageServerConnection ls = CopilotCore.getPlugin().getCopilotLanguageServer();
     if (ls == null) {
       target.markSealed();
-      target.showCompleted(Messages.thinking_completedTitle);
+      target.showCompleted();
       requestLayout();
       return;
     }
@@ -99,16 +99,15 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
             return;
           }
           if (resp != null && StringUtils.isNotBlank(resp.title())) {
-            target.showCompleted(resp.title());
-          } else {
-            target.showCompleted(Messages.thinking_completedTitle);
+            target.setTitle(resp.title());
           }
+          target.showCompleted();
           requestLayout();
         }, this))
         .exceptionally(ex -> {
           SwtUtils.invokeOnDisplayThreadAsync(() -> {
             if (!isDisposed() && !target.isDisposed() && !target.isFinalized()) {
-              target.showCompleted(Messages.thinking_completedTitle);
+              target.showCompleted();
               requestLayout();
             }
           }, this);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/messages.properties
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/messages.properties
@@ -35,8 +35,6 @@ todoList_clearButtonDisabled=Cannot clear todos while a task is in progress
 todoList_expandTooltip=Click to expand the todo list
 todoList_collapseTooltip=Click to collapse the todo list
 
-thinking_inProgressTitle=Thinking...
-thinking_completedTitle=Thinking completed
-thinking_cancelledTitle=Thinking cancelled
+thinking_title=Thinking
 thinking_expandTooltip=Click to show the thinking details
 thinking_collapseTooltip=Click to hide the thinking details


### PR DESCRIPTION
resolve #192 
<img width="598" height="340" alt="image" src="https://github.com/user-attachments/assets/3c0aba00-bdd0-4182-91fa-bcc7bb729370" />
<img width="580" height="286" alt="image" src="https://github.com/user-attachments/assets/571442a5-8e2b-4d19-a221-e7060163bd35" />
<img width="582" height="161" alt="image" src="https://github.com/user-attachments/assets/4a49e951-f479-4a59-b554-38eaf3c708bc" />
<img width="608" height="298" alt="image" src="https://github.com/user-attachments/assets/8ed8e0e5-7f1e-481f-beec-dfae77448daf" />
