### PR TITLE
feat - Persist thinking blocks to conversation history and restore on session switch

### DIFF
--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -35,10 +36,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.copilot.eclipse.core.AuthStatusManager;
 import com.microsoft.copilot.eclipse.core.logger.CopilotForEclipseLogger;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.AgentRound;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatProgressValue;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotModel;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.Thinking;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.EditAgentRoundData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockState;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
 
 @ExtendWith(MockitoExtension.class)
@@ -187,7 +193,7 @@ class ConversationPersistenceManagerTests {
 
     when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
 
-    CompletableFuture<Void> result = persistenceManager.cacheConversationProgress(conversationId, progress);
+    CompletableFuture<Void> result = persistenceManager.cacheConversationProgress(conversationId, progress, null);
 
     result.get(); // Wait for completion
 
@@ -199,6 +205,76 @@ class ConversationPersistenceManagerTests {
   }
 
   @Test
+  void testUpdateThinkingBlockTitle_updatesCachedThinkingBlockById() throws Exception {
+    ConversationPersistenceManager manager = createManagerWithRealDataFactory();
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    String turnId = "00000000-0000-0000-0000-000000000002";
+    String thinkingBlockId = "thinking-block-1";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
+
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "thinking content"), thinkingBlockId).get();
+    manager.updateThinkingBlockTitle(conversationId, turnId, thinkingBlockId, "Generated title").get();
+
+    ThinkingBlockData block = getCachedCopilotTurn(manager, conversationId, turnId).getReply()
+      .getEditAgentRounds().get(0).getThinkingBlock();
+    assertNotNull(block);
+    assertEquals(thinkingBlockId, block.getId());
+    assertEquals("Generated title", block.getTitle());
+  }
+
+  @Test
+  void testCancelThinkingBlock_updatesCachedThinkingBlockById() throws Exception {
+    ConversationPersistenceManager manager = createManagerWithRealDataFactory();
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    String turnId = "00000000-0000-0000-0000-000000000002";
+    String thinkingBlockId = "thinking-block-1";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
+
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "thinking content"), thinkingBlockId).get();
+    manager.cancelThinkingBlock(conversationId, turnId, thinkingBlockId).get();
+
+    ThinkingBlockData block = getCachedCopilotTurn(manager, conversationId, turnId).getReply()
+      .getEditAgentRounds().get(0).getThinkingBlock();
+    assertNotNull(block);
+    assertEquals(thinkingBlockId, block.getId());
+    assertEquals(ThinkingBlockState.CANCELLED, block.getState());
+  }
+
+  @Test
+  void testCacheConversationProgress_withThinkingBlockId_updatesMatchingPlaceholderRound() throws Exception {
+    ConversationPersistenceManager manager = createManagerWithRealDataFactory();
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    String turnId = "00000000-0000-0000-0000-000000000002";
+    String firstThinkingBlockId = "thinking-block-1";
+    String secondThinkingBlockId = "thinking-block-2";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
+
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "first"), firstThinkingBlockId).get();
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "second"), secondThinkingBlockId).get();
+    manager.cacheConversationProgress(conversationId,
+        createAgentRoundProgressValue(conversationId, turnId, 1, "round reply"), secondThinkingBlockId).get();
+
+    ReplyData reply = getCachedCopilotTurn(manager, conversationId, turnId).getReply();
+    List<EditAgentRoundData> rounds = reply.getEditAgentRounds();
+    assertEquals(2, rounds.size());
+    EditAgentRoundData updatedRound = rounds.stream()
+        .filter(round -> round.getRoundId() == 1)
+        .findFirst()
+        .orElseThrow();
+    assertEquals(secondThinkingBlockId, updatedRound.getThinkingBlock().getId());
+    assertEquals("round reply", updatedRound.getReply());
+    assertTrue(rounds.stream()
+        .anyMatch(round -> firstThinkingBlockId.equals(round.getThinkingBlock().getId())));
+  }
+
+  @Test
   void testPersistConversationProgress_Success() throws Exception {
     String conversationId = "00000000-0000-0000-0000-000000000000";
     ChatProgressValue progress = createTestChatProgressValue();
@@ -206,7 +282,7 @@ class ConversationPersistenceManagerTests {
 
     when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
 
-    CompletableFuture<Void> result = persistenceManager.persistConversationProgress(conversationId, progress);
+    CompletableFuture<Void> result = persistenceManager.persistConversationProgress(conversationId, progress, null);
 
     result.get(); // Wait for completion
 
@@ -229,7 +305,7 @@ class ConversationPersistenceManagerTests {
     assertNotNull(result);
     assertEquals(conversationId, result.getConversationId());
     verify(mockDataFactory).updateConversationMetadata(newConversationData, progress);
-    verify(mockDataFactory).updateReplyFromProgress(any(), eq(progress));
+    verify(mockDataFactory).updateReplyFromProgress(any(), eq(progress), isNull());
   }
 
   // Helper methods to create test data
@@ -293,5 +369,51 @@ class ConversationPersistenceManagerTests {
     progress.setReply("Test reply");
     progress.setSuggestedTitle("Test Suggested Title");
     return progress;
+  }
+
+  private ConversationPersistenceManager createManagerWithRealDataFactory() throws Exception {
+    ConversationPersistenceManager manager = new ConversationPersistenceManager(mockAuthStatusManager);
+    setPrivateField(manager, "persistenceService", mockPersistenceService);
+    return manager;
+  }
+
+  private CopilotTurnData getCachedCopilotTurn(ConversationPersistenceManager manager, String conversationId,
+      String turnId) throws Exception {
+    ConversationData conversationData = manager.loadConversation(conversationId).get();
+    assertNotNull(conversationData);
+    return conversationData.getTurns().stream()
+        .filter(CopilotTurnData.class::isInstance)
+        .map(CopilotTurnData.class::cast)
+        .filter(turn -> turnId.equals(turn.getTurnId()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private ChatProgressValue createThinkingProgressValue(String conversationId, String turnId, String thinkingText) {
+    ChatProgressValue progress = new ChatProgressValue();
+    progress.setKind(WorkDoneProgressKind.report);
+    progress.setConversationId(conversationId);
+    progress.setTurnId(turnId);
+    progress.setThinking(new Thinking("server-thinking-id", thinkingText, null));
+    return progress;
+  }
+
+  private ChatProgressValue createAgentRoundProgressValue(String conversationId, String turnId, int roundId,
+      String reply) throws Exception {
+    ChatProgressValue progress = new ChatProgressValue();
+    progress.setKind(WorkDoneProgressKind.report);
+    progress.setConversationId(conversationId);
+    progress.setTurnId(turnId);
+    AgentRound round = new AgentRound();
+    setPrivateField(round, "roundId", roundId);
+    setPrivateField(round, "reply", reply);
+    setPrivateField(progress, "editAgentRounds", List.of(round));
+    return progress;
+  }
+
+  private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+    var field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 }

--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
@@ -275,6 +275,28 @@ class ConversationPersistenceManagerTests {
   }
 
   @Test
+  void testCacheConversationProgress_preservesWhitespaceOnlyThinkingFragments() throws Exception {
+    ConversationPersistenceManager manager = createManagerWithRealDataFactory();
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    String turnId = "00000000-0000-0000-0000-000000000002";
+    String thinkingBlockId = "thinking-block-1";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    when(mockPersistenceService.loadConversationFromPersistedJsonFile(conversationId)).thenReturn(conversationData);
+
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "before title."), thinkingBlockId).get();
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "\n"), thinkingBlockId).get();
+    manager.cacheConversationProgress(conversationId,
+        createThinkingProgressValue(conversationId, turnId, "**Next title**\n\nbody"), thinkingBlockId).get();
+
+    ThinkingBlockData block = getCachedCopilotTurn(manager, conversationId, turnId).getReply()
+        .getEditAgentRounds().get(0).getThinkingBlock();
+    assertNotNull(block);
+    assertEquals("before title.\n**Next title**\n\nbody", block.getContent());
+  }
+
+  @Test
   void testPersistConversationProgress_Success() throws Exception {
     String conversationId = "00000000-0000-0000-0000-000000000000";
     ChatProgressValue progress = createTestChatProgressValue();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -19,11 +19,14 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.AgentToolCall;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatCompletionContentPart;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatProgressValue;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ConversationError;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.Thinking;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.EditAgentRoundData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ErrorData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ErrorMessageData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockState;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ToolCallData;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
 
@@ -32,6 +35,8 @@ import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
  * no business logic.
  */
 public class ConversationDataFactory {
+  private static final int SYNTHETIC_ROUND_ID = -1;
+
   private final AuthStatusManager authStatusManager;
 
   /**
@@ -95,12 +100,16 @@ public class ConversationDataFactory {
    *
    * @param reply the reply data to update
    * @param progress the progress value to extract data from
+   * @param thinkingBlockId the UI-generated thinking block ID, when the progress belongs to a thinking round
    */
-  public void updateReplyFromProgress(ReplyData reply, ChatProgressValue progress) {
+  public void updateReplyFromProgress(ReplyData reply, ChatProgressValue progress, String thinkingBlockId) {
     ensureReplyInitialized(reply);
 
+    // Accumulate thinking content
+    appendThinkingContent(reply, progress.getThinking(), thinkingBlockId);
+
     // Merge agent rounds and append tool calls
-    mergeAgentRounds(reply, progress.getAgentRounds());
+    mergeAgentRounds(reply, progress.getAgentRounds(), thinkingBlockId);
 
     // Handle plain reply streaming (no agentRounds)
     appendProgressReplyText(reply, progress.getReply());
@@ -117,27 +126,25 @@ public class ConversationDataFactory {
     reply.setHideText(progress.isHideText());
   }
 
-  private void mergeAgentRounds(ReplyData reply, List<AgentRound> agentRounds) {
+  private void mergeAgentRounds(ReplyData reply, List<AgentRound> agentRounds, String thinkingBlockId) {
     if (agentRounds == null || agentRounds.isEmpty()) {
       return;
     }
+    boolean thinkingRoundUpdated = false;
     for (AgentRound round : agentRounds) {
-      EditAgentRoundData existingRound = findRoundById(reply.getEditAgentRounds(), round.getRoundId());
+      EditAgentRoundData existingRound = thinkingRoundUpdated
+          ? null : findRoundByThinkingBlockId(reply.getEditAgentRounds(), thinkingBlockId);
+      if (existingRound != null) {
+        thinkingRoundUpdated = true;
+      }
+      if (existingRound == null) {
+        existingRound = findRoundById(reply.getEditAgentRounds(), round.getRoundId());
+      }
       if (existingRound == null) {
         EditAgentRoundData er = convertAgentRoundToEditAgentRoundData(round);
         reply.getEditAgentRounds().add(er);
       } else {
-        appendReplyToAgentRound(existingRound, round.getReply());
-        if (round.getToolCalls() != null && !round.getToolCalls().isEmpty()) {
-          for (AgentToolCall tc : round.getToolCalls()) {
-            ToolCallData existingToolCall = findToolCallById(existingRound.getToolCalls(), tc.getId());
-            if (existingToolCall == null) {
-              existingRound.getToolCalls().add(convertAgentToolCallToToolCallData(tc));
-            } else {
-              updateToolCallData(existingToolCall, tc);
-            }
-          }
-        }
+        updateAgentRoundData(existingRound, round);
       }
     }
   }
@@ -170,6 +177,18 @@ public class ConversationDataFactory {
   private void appendReplyToAgentRound(EditAgentRoundData round, String addition) {
     String existingReply = StringUtils.isBlank(round.getReply()) ? "" : round.getReply();
     round.setReply(existingReply + addition);
+  }
+
+  private void appendThinkingContent(ReplyData reply, Thinking thinking, String thinkingBlockId) {
+    if (thinking == null || StringUtils.isBlank(thinking.text())) {
+      return;
+    }
+    if (StringUtils.isBlank(thinkingBlockId)) {
+      return;
+    }
+    EditAgentRoundData round = getOrCreateThinkingRound(reply, thinkingBlockId);
+    ThinkingBlockData block = round.getThinkingBlock();
+    block.setContent(StringUtils.defaultString(block.getContent()) + thinking.text());
   }
 
   private void applyConversationError(ReplyData reply, ConversationError error) {
@@ -278,6 +297,55 @@ public class ConversationDataFactory {
   }
 
   // Private helper methods for data transformation
+  private EditAgentRoundData getOrCreateThinkingRound(ReplyData reply, String thinkingBlockId) {
+    EditAgentRoundData existingRound = findRoundByThinkingBlockId(reply.getEditAgentRounds(), thinkingBlockId);
+    if (existingRound != null) {
+      return existingRound;
+    }
+    EditAgentRoundData round = new EditAgentRoundData();
+    round.setRoundId(SYNTHETIC_ROUND_ID);
+    round.setToolCalls(new ArrayList<>());
+    round.setThinkingBlock(new ThinkingBlockData(thinkingBlockId, ""));
+    reply.getEditAgentRounds().add(round);
+    return round;
+  }
+
+  private void updateAgentRoundData(EditAgentRoundData target, AgentRound source) {
+    target.setRoundId(source.getRoundId());
+    appendReplyToAgentRound(target, source.getReply());
+    ThinkingBlockData thinkingBlock = target.getThinkingBlock();
+    if (thinkingBlock != null && !thinkingBlock.isFinalized()) {
+      thinkingBlock.setState(ThinkingBlockState.COMPLETED);
+    }
+    if (source.getToolCalls() == null || source.getToolCalls().isEmpty()) {
+      return;
+    }
+    if (target.getToolCalls() == null) {
+      target.setToolCalls(new ArrayList<>());
+    }
+    for (AgentToolCall toolCall : source.getToolCalls()) {
+      ToolCallData existingToolCall = findToolCallById(target.getToolCalls(), toolCall.getId());
+      if (existingToolCall == null) {
+        target.getToolCalls().add(convertAgentToolCallToToolCallData(toolCall));
+      } else {
+        updateToolCallData(existingToolCall, toolCall);
+      }
+    }
+  }
+
+  private EditAgentRoundData findRoundByThinkingBlockId(List<EditAgentRoundData> rounds, String thinkingBlockId) {
+    if (rounds == null || StringUtils.isBlank(thinkingBlockId)) {
+      return null;
+    }
+    for (EditAgentRoundData round : rounds) {
+      ThinkingBlockData thinkingBlock = round.getThinkingBlock();
+      if (thinkingBlock != null && thinkingBlockId.equals(thinkingBlock.getId())) {
+        return round;
+      }
+    }
+    return null;
+  }
+
   private EditAgentRoundData findRoundById(List<EditAgentRoundData> rounds, int roundId) {
     if (rounds == null) {
       return null;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -180,7 +180,8 @@ public class ConversationDataFactory {
   }
 
   private void appendThinkingContent(ReplyData reply, Thinking thinking, String thinkingBlockId) {
-    if (thinking == null || StringUtils.isBlank(thinking.text())) {
+    // Preserve whitespace-only thinking fragments; they can carry markdown boundaries between sections.
+    if (thinking == null || StringUtils.isEmpty(thinking.text())) {
       return;
     }
     if (StringUtils.isBlank(thinkingBlockId)) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
@@ -317,7 +317,7 @@ public class ConversationPersistenceManager {
   }
 
   /**
-  * Sets the title on the thinking block with the given ID.
+   * Sets the title on the thinking block with the given ID.
    *
    * @param conversationId the conversation ID
    * @param turnId the turn ID
@@ -343,7 +343,7 @@ public class ConversationPersistenceManager {
   }
 
   /**
-  * Cancels the thinking block with the given ID.
+   * Cancels the thinking block with the given ID.
    *
    * @param conversationId the conversation ID
    * @param turnId the turn ID
@@ -394,7 +394,6 @@ public class ConversationPersistenceManager {
     }
     return null;
   }
-
 
   /**
    * Finds a turn by ID and type in the conversation.

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
@@ -24,6 +24,10 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotModel;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.TodoItem;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.codingagent.CodingAgentMessageRequestParams;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.EditAgentRoundData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockState;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
 
 /**
@@ -201,12 +205,18 @@ public class ConversationPersistenceManager {
 
   /**
    * Updates a conversation with progress data and caches it only (no disk persistence).
+   *
+   * @param conversationId the conversation ID
+   * @param progress the progress value
+   * @param thinkingBlockId the UI-generated thinking block ID, when the progress belongs to a thinking round
    */
-  public CompletableFuture<Void> cacheConversationProgress(String conversationId, ChatProgressValue progress) {
+  public CompletableFuture<Void> cacheConversationProgress(String conversationId, ChatProgressValue progress,
+      String thinkingBlockId) {
     return CompletableFuture.runAsync(() -> {
       lock.writeLock().lock();
       try {
-        ConversationData conversationData = updateConversationProgressInternal(conversationId, progress);
+        ConversationData conversationData = updateConversationProgressInternal(conversationId, progress,
+            thinkingBlockId);
         conversationCache.put(conversationId, conversationData);
       } catch (Exception e) {
         CopilotCore.LOGGER.error("Failed to cache conversation progress: " + conversationId, e);
@@ -218,12 +228,18 @@ public class ConversationPersistenceManager {
 
   /**
    * Updates a conversation with progress data and persists it to disk.
+   *
+   * @param conversationId the conversation ID
+   * @param progress the progress value
+   * @param thinkingBlockId the UI-generated thinking block ID, when the progress belongs to a thinking round
    */
-  public CompletableFuture<Void> persistConversationProgress(String conversationId, ChatProgressValue progress) {
+  public CompletableFuture<Void> persistConversationProgress(String conversationId, ChatProgressValue progress,
+      String thinkingBlockId) {
     return CompletableFuture.runAsync(() -> {
       lock.writeLock().lock();
       try {
-        ConversationData conversationData = updateConversationProgressInternal(conversationId, progress);
+        ConversationData conversationData = updateConversationProgressInternal(conversationId, progress,
+            thinkingBlockId);
         persistAndCacheConversation(conversationData);
       } catch (IOException e) {
         CopilotCore.LOGGER.error("Failed to persist conversation progress: " + conversationId, e);
@@ -262,7 +278,7 @@ public class ConversationPersistenceManager {
     return CompletableFuture.supplyAsync(() -> {
       lock.writeLock().lock();
       try {
-        return updateConversationProgressInternal(conversationId, progress);
+        return updateConversationProgressInternal(conversationId, progress, null);
       } catch (IOException e) {
         CopilotCore.LOGGER.error("Failed to update conversation progress: " + conversationId, e);
         throw new RuntimeException("Failed to update conversation progress", e);
@@ -275,8 +291,8 @@ public class ConversationPersistenceManager {
   /**
    * Internal method to update conversation progress without locking (caller must hold write lock).
    */
-  private ConversationData updateConversationProgressInternal(String conversationId, ChatProgressValue progress)
-      throws IOException {
+  private ConversationData updateConversationProgressInternal(String conversationId, ChatProgressValue progress,
+      String thinkingBlockId) throws IOException {
     ConversationData conversationData = getOrCreateNewConversationById(conversationId);
 
     // Update conversation metadata using factory
@@ -284,7 +300,8 @@ public class ConversationPersistenceManager {
 
     // Find or create turn and update it
     CopilotTurnData copilotTurnData = findOrCreateCopilotTurn(conversationData, progress.getTurnId());
-    dataFactory.updateReplyFromProgress(copilotTurnData.getReply(), progress);
+    ReplyData reply = copilotTurnData.getReply();
+    dataFactory.updateReplyFromProgress(reply, progress, thinkingBlockId);
 
     // Mark subagent turns with their parent turn ID
     if (StringUtils.isNotBlank(progress.getParentTurnId())) {
@@ -298,6 +315,86 @@ public class ConversationPersistenceManager {
 
     return conversationData;
   }
+
+  /**
+  * Sets the title on the thinking block with the given ID.
+   *
+   * @param conversationId the conversation ID
+   * @param turnId the turn ID
+   * @param thinkingBlockId the thinking block ID
+   * @param title the generated title
+   */
+  public CompletableFuture<Void> updateThinkingBlockTitle(String conversationId, String turnId, String thinkingBlockId,
+      String title) {
+    if (StringUtils.isAnyBlank(conversationId, turnId, thinkingBlockId, title)) {
+      return CompletableFuture.completedFuture(null);
+    }
+    return CompletableFuture.runAsync(() -> {
+      lock.writeLock().lock();
+      try {
+        ThinkingBlockData block = findThinkingBlock(conversationId, turnId, thinkingBlockId);
+        if (block != null) {
+          block.setTitle(title);
+        }
+      } finally {
+        lock.writeLock().unlock();
+      }
+    });
+  }
+
+  /**
+  * Cancels the thinking block with the given ID.
+   *
+   * @param conversationId the conversation ID
+   * @param turnId the turn ID
+   * @param thinkingBlockId the thinking block ID
+   */
+  public CompletableFuture<Void> cancelThinkingBlock(String conversationId, String turnId, String thinkingBlockId) {
+    if (StringUtils.isAnyBlank(conversationId, turnId, thinkingBlockId)) {
+      return CompletableFuture.completedFuture(null);
+    }
+    return CompletableFuture.runAsync(() -> {
+      lock.writeLock().lock();
+      try {
+        ThinkingBlockData block = findThinkingBlock(conversationId, turnId, thinkingBlockId);
+        if (block != null) {
+          block.setState(ThinkingBlockState.CANCELLED);
+        }
+      } finally {
+        lock.writeLock().unlock();
+      }
+    });
+  }
+
+  private ThinkingBlockData findThinkingBlock(String conversationId, String turnId, String thinkingBlockId) {
+    ConversationData conversationData = conversationCache.get(conversationId);
+    if (conversationData == null) {
+      return null;
+    }
+    CopilotTurnData turn = findTurn(conversationData, turnId, CopilotTurnData.class);
+    if (turn == null || turn.getReply() == null) {
+      return null;
+    }
+    return findThinkingBlock(turn.getReply(), thinkingBlockId);
+  }
+
+  private ThinkingBlockData findThinkingBlock(ReplyData reply, String thinkingBlockId) {
+    if (reply == null || StringUtils.isBlank(thinkingBlockId)) {
+      return null;
+    }
+    List<EditAgentRoundData> rounds = reply.getEditAgentRounds();
+    if (rounds == null) {
+      return null;
+    }
+    for (EditAgentRoundData round : rounds) {
+      ThinkingBlockData block = round.getThinkingBlock();
+      if (block != null && thinkingBlockId.equals(block.getId())) {
+        return block;
+      }
+    }
+    return null;
+  }
+
 
   /**
    * Finds a turn by ID and type in the conversation.

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/CopilotTurnData.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/CopilotTurnData.java
@@ -365,7 +365,8 @@ public class CopilotTurnData extends AbstractTurnData {
           && hideText == other.hideText && Objects.equals(notifications, other.notifications)
           && Objects.equals(panelMessages, other.panelMessages) && Objects.equals(rating, other.rating)
           && Objects.equals(references, other.references) && Objects.equals(steps, other.steps)
-          && Objects.equals(agentMessages, other.agentMessages) && Objects.equals(text, other.text)
+          && Objects.equals(agentMessages, other.agentMessages)
+          && Objects.equals(text, other.text)
           && Objects.equals(modelName, other.modelName)
           && Double.compare(billingMultiplier, other.billingMultiplier) == 0
           && Objects.equals(reasoningEffort, other.reasoningEffort);
@@ -531,6 +532,7 @@ public class CopilotTurnData extends AbstractTurnData {
     private String reply;
     private List<ToolCallData> toolCalls;
     private Map<String, Object> data;
+    private ThinkingBlockData thinkingBlock;
 
     public int getRoundId() {
       return roundId;
@@ -564,9 +566,17 @@ public class CopilotTurnData extends AbstractTurnData {
       this.data = data;
     }
 
+    public ThinkingBlockData getThinkingBlock() {
+      return thinkingBlock;
+    }
+
+    public void setThinkingBlock(ThinkingBlockData thinkingBlock) {
+      this.thinkingBlock = thinkingBlock;
+    }
+
     @Override
     public int hashCode() {
-      return Objects.hash(data, reply, roundId, toolCalls);
+      return Objects.hash(data, reply, roundId, toolCalls, thinkingBlock);
     }
 
     @Override
@@ -582,7 +592,7 @@ public class CopilotTurnData extends AbstractTurnData {
       }
       EditAgentRoundData other = (EditAgentRoundData) obj;
       return Objects.equals(data, other.data) && Objects.equals(reply, other.reply) && roundId == other.roundId
-          && Objects.equals(toolCalls, other.toolCalls);
+          && Objects.equals(toolCalls, other.toolCalls) && Objects.equals(thinkingBlock, other.thinkingBlock);
     }
 
     @Override
@@ -592,6 +602,7 @@ public class CopilotTurnData extends AbstractTurnData {
       builder.append("reply", reply);
       builder.append("toolCalls", toolCalls);
       builder.append("data", data);
+      builder.append("thinkingBlock", thinkingBlock);
       return builder.toString();
     }
   }
@@ -770,6 +781,104 @@ public class CopilotTurnData extends AbstractTurnData {
       builder.append("prLink", prLink);
       builder.append("agentSlug", agentSlug);
       builder.append("data", data);
+      return builder.toString();
+    }
+  }
+
+  /** Possible final states for a thinking block. */
+  public enum ThinkingBlockState {
+    /** The thinking block completed normally. */
+    COMPLETED,
+    /** The thinking block was cancelled by the user. */
+    CANCELLED
+  }
+
+  /** Data class representing a persisted thinking block. */
+  public static class ThinkingBlockData {
+    private ThinkingBlockState state;
+    private String id;
+    private String content;
+    private String title;
+
+    /** Default constructor. */
+    public ThinkingBlockData() {
+    }
+
+    /** Construct with id and content. */
+    public ThinkingBlockData(String id, String content) {
+      this.id = id;
+      this.content = content;
+    }
+
+    public ThinkingBlockState getState() {
+      return state;
+    }
+
+    public void setState(ThinkingBlockState state) {
+      this.state = state;
+    }
+
+    public boolean isCompleted() {
+      return state == ThinkingBlockState.COMPLETED;
+    }
+
+    public boolean isCancelled() {
+      return state == ThinkingBlockState.CANCELLED;
+    }
+
+    public boolean isFinalized() {
+      return state != null;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getContent() {
+      return content;
+    }
+
+    public void setContent(String content) {
+      this.content = content;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public void setTitle(String title) {
+      this.title = title;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, content, title, state);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null || getClass() != obj.getClass()) {
+        return false;
+      }
+      ThinkingBlockData other = (ThinkingBlockData) obj;
+      return Objects.equals(id, other.id) && Objects.equals(content, other.content)
+          && Objects.equals(title, other.title) && Objects.equals(state, other.state);
+    }
+
+    @Override
+    public String toString() {
+      ToStringBuilder builder = new ToStringBuilder(this);
+      builder.append("id", id);
+      builder.append("content", content);
+      builder.append("title", title);
+      builder.append("state", state);
       return builder.toString();
     }
   }

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlockParseTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlockParseTest.java
@@ -105,6 +105,31 @@ class ThinkingBlockParseTest {
     assertEquals("body two", body(sections.get(1)));
   }
 
+  @Test
+  void parseSections_adjacentTitles_withNoBodyBetween() throws Exception {
+    // Two titles back-to-back with no body text between them must not throw
+    // StringIndexOutOfBoundsException (regression test for cursor > matcher.start() case).
+    String raw = "**Title1**\n**Title2**\nbody after both";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(2, sections.size());
+    assertEquals("Title1", title(sections.get(0)));
+    assertEquals("", body(sections.get(0)));
+    assertEquals("Title2", title(sections.get(1)));
+    assertEquals("body after both", body(sections.get(1)));
+  }
+
+  @Test
+  void parseSections_adjacentTitles_crlf() throws Exception {
+    // Same scenario with CRLF line endings.
+    String raw = "**Title1**\r\n**Title2**\r\nbody";
+    List<?> sections = invokeParseSections(raw);
+    assertEquals(2, sections.size());
+    assertEquals("Title1", title(sections.get(0)));
+    assertEquals("", body(sections.get(0)));
+    assertEquals("Title2", title(sections.get(1)));
+    assertEquals("body", body(sections.get(1)));
+  }
+
   private static String invokeStripTrailingNewlines(String input) throws Exception {
     Method m = ThinkingBlock.class.getDeclaredMethod("stripTrailingNewlines", String.class);
     m.setAccessible(true);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
@@ -395,12 +395,21 @@ public abstract class BaseTurnWidget extends Composite {
       return;
     }
 
+    // Restore thinking blocks for the subagent
+    BaseTurnWidget subagentWidget = block.getSubagentTurnWidget();
+    ThinkingTurnWidget thinkingWidget =
+        subagentWidget instanceof ThinkingTurnWidget ? (ThinkingTurnWidget) subagentWidget : null;
+
     if (StringUtils.isNotBlank(replyData.getText())) {
       block.appendMessage(replyData.getText());
     }
 
     if (replyData.getEditAgentRounds() != null) {
       for (EditAgentRoundData round : replyData.getEditAgentRounds()) {
+        // Restore thinking block before the round's reply and tool calls
+        if (thinkingWidget != null && round.getThinkingBlock() != null) {
+          thinkingWidget.restoreThinkingBlock(round.getThinkingBlock());
+        }
         if (round.getReply() != null && !round.getReply().isEmpty()) {
           block.appendMessage(round.getReply());
         }
@@ -415,14 +424,14 @@ public abstract class BaseTurnWidget extends Composite {
 
     // Restore error messages into the subagent block
     if (replyData.getErrorMessages() != null) {
-      BaseTurnWidget subagentWidget = block.getSubagentTurnWidget();
-      if (subagentWidget != null) {
+      BaseTurnWidget errorWidget = block.getSubagentTurnWidget();
+      if (errorWidget != null) {
         for (CopilotTurnData.ErrorMessageData errorMessageData : replyData.getErrorMessages()) {
           CopilotTurnData.ErrorData errorData = errorMessageData.getError();
           String errorMessage = errorData != null ? errorData.getMessage() : "";
           int errorCode = errorData != null ? errorData.getCode() : 0;
           String modelProviderName = errorData != null ? errorData.getModelProviderName() : null;
-          subagentWidget.createWarnDialog(errorMessage, errorCode, modelProviderName);
+          errorWidget.createWarnDialog(errorMessage, errorCode, modelProviderName);
         }
       }
     }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -58,10 +59,12 @@ public class ChatContentViewer extends ScrolledComposite {
       Pattern.compile("\\s*\\|?\\s*(?:GitHub\\s+)?Request\\s+ID:\\s*\\S+\\.?", Pattern.CASE_INSENSITIVE);
 
   private ChatServiceManager serviceManager;
+  private String conversationId;
 
   private Composite cmpContent;
 
   private Map<String, BaseTurnWidget> turns;
+  private Map<String, String> activeThinkingBlockIds;
   private Composite errorWidget;
 
   private BaseTurnWidget latestUserTurn;
@@ -117,6 +120,7 @@ public class ChatContentViewer extends ScrolledComposite {
     }
 
     this.turns = new HashMap<>();
+    this.activeThinkingBlockIds = new ConcurrentHashMap<>();
 
     this.serviceManager = serviceManager;
 
@@ -166,11 +170,17 @@ public class ChatContentViewer extends ScrolledComposite {
       }
 
       turns.put(workDoneToken, turnWidget);
+      activeThinkingBlockIds.remove(workDoneToken);
       ref.set(turnWidget);
     }, this);
 
     return ref.get();
 
+  }
+
+  /** Set the conversation ID used for thinking-block persistence. */
+  public void setConversationId(String conversationId) {
+    this.conversationId = conversationId;
   }
 
   /**
@@ -191,7 +201,9 @@ public class ChatContentViewer extends ScrolledComposite {
 
       if (value.getKind() == WorkDoneProgressKind.report) {
         if (turnWidget instanceof ThinkingTurnWidget thinkingTurn) {
+          thinkingTurn.setConversationContext(conversationId, value.getTurnId());
           thinkingTurn.appendThinking(value.getThinking());
+          updateActiveThinkingBlockId(value.getTurnId(), thinkingTurn);
           if (hasRenderableOutput(value)) {
             // Seal before appending the reply so the spinner stops and the title is fetched.
             thinkingTurn.sealThinking();
@@ -221,6 +233,7 @@ public class ChatContentViewer extends ScrolledComposite {
         // Seal any in-progress thinking block before the turn ends.
         if (turnWidget instanceof ThinkingTurnWidget thinkingTurn) {
           thinkingTurn.sealThinking();
+          updateActiveThinkingBlockId(value.getTurnId(), thinkingTurn);
         }
         turnWidget.notifyTurnEnd();
       }
@@ -288,6 +301,20 @@ public class ChatContentViewer extends ScrolledComposite {
         }
       }
     }, this);
+  }
+
+  /** Returns the active thinking block ID last observed while processing this turn's progress. */
+  public String getActiveThinkingBlockId(String turnId) {
+    return activeThinkingBlockIds.get(turnId);
+  }
+
+  private void updateActiveThinkingBlockId(String turnId, ThinkingTurnWidget thinkingTurn) {
+    String thinkingBlockId = thinkingTurn.getActiveThinkingBlockId();
+    if (StringUtils.isBlank(thinkingBlockId)) {
+      activeThinkingBlockIds.remove(turnId);
+    } else {
+      activeThinkingBlockIds.put(turnId, thinkingBlockId);
+    }
   }
 
   /**

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
@@ -826,10 +826,14 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
             this.conversationId = newConversationId;
             this.conversationState = ConversationState.CONTINUED_CONVERSATION;
           }
+          // Always sync conversationId — chatContentViewer may have been recreated
+          if (this.chatContentViewer != null) {
+            this.chatContentViewer.setConversationId(this.conversationId);
+          }
         }
 
         // Cache conversation progress on begin
-        persistenceManager.cacheConversationProgress(this.conversationId, value);
+        persistenceManager.cacheConversationProgress(this.conversationId, value, null);
 
         // Set the CLS-assigned turnId on the last user turn that doesn't have one yet.
         // Chain off persistUserTurnFuture to ensure the UserTurnData has been created first.
@@ -878,6 +882,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
         if (this.chatContentViewer != null) {
           this.chatContentViewer.processTurnEvent(value);
         }
+        String thinkingBlockId = this.chatContentViewer != null
+            ? this.chatContentViewer.getActiveThinkingBlockId(value.getTurnId()) : null;
 
         // Track run_subagent tool call ID for associating subagent turns
         if (StringUtils.isBlank(value.getParentTurnId()) && value.getAgentRounds() != null) {
@@ -902,7 +908,7 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
         if (persistenceManager != null) {
           final String currentConversationId = this.conversationId;
           final String subagentToolCallId = this.lastRunSubagentToolCallId;
-          persistenceManager.cacheConversationProgress(currentConversationId, value)
+          persistenceManager.cacheConversationProgress(currentConversationId, value, thinkingBlockId)
               .thenCompose(v -> {
                 if (StringUtils.isNotBlank(value.getParentTurnId())
                     && StringUtils.isNotBlank(subagentToolCallId)) {
@@ -924,10 +930,12 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
           this.actionBar.resetSendButton();
           this.topBanner.updateTitle(value.getSuggestedTitle());
         }
+        String endThinkingBlockId = this.chatContentViewer != null
+            ? this.chatContentViewer.getActiveThinkingBlockId(value.getTurnId()) : null;
 
         // Persist final conversation state and conversation title on end
         if (persistenceManager != null) {
-          persistenceManager.persistConversationProgress(this.conversationId, value);
+          persistenceManager.persistConversationProgress(this.conversationId, value, endThinkingBlockId);
 
           // Persist todo list at end phase
           TodoListService todoListService = chatServiceManager.getTodoListService();
@@ -1746,12 +1754,19 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
       return;
     }
 
+    ThinkingTurnWidget thinkingWidget =
+        turnWidget instanceof ThinkingTurnWidget ? (ThinkingTurnWidget) turnWidget : null;
+
     if (StringUtils.isNotBlank(replyData.getText())) {
       turnWidget.appendMessage(replyData.getText());
     }
 
     if (replyData.getEditAgentRounds() != null && !replyData.getEditAgentRounds().isEmpty()) {
       for (EditAgentRoundData round : replyData.getEditAgentRounds()) {
+        // Restore thinking block before the round's reply and tool calls
+        if (thinkingWidget != null && round.getThinkingBlock() != null) {
+          thinkingWidget.restoreThinkingBlock(round.getThinkingBlock());
+        }
         if (round.getReply() != null && !round.getReply().isEmpty()) {
           turnWidget.appendMessage(round.getReply());
         }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -6,6 +6,7 @@ package com.microsoft.copilot.eclipse.ui.chat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,6 +24,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 
+import com.microsoft.copilot.eclipse.core.CopilotCore;
 import com.microsoft.copilot.eclipse.ui.CopilotUi;
 import com.microsoft.copilot.eclipse.ui.chat.services.ChatServiceManager;
 import com.microsoft.copilot.eclipse.ui.swt.SpinnerAnimator;
@@ -63,6 +65,7 @@ public class ThinkingBlock extends Composite {
    */
   private enum State { STREAMING, SEALED, COMPLETED, CANCELLED }
 
+  private final String thinkingId = UUID.randomUUID().toString();
   private State state = State.STREAMING;
   private SpinnerAnimator spinner;
   private Image cancelledIcon;
@@ -121,14 +124,14 @@ public class ThinkingBlock extends Composite {
    * content finished, title fetch in flight), simply finalizes as completed since thinking itself was not interrupted.
    * No-op if already finalized.
    */
-  public void showCancelled() {
+  public boolean showCancelled() {
     if (isFinalized()) {
-      return;
+      return false;
     }
     if (state == State.SEALED) {
       // Thinking content already finished; just finalize without the cancel icon.
       showCompleted();
-      return;
+      return false;
     }
     stopSpinner();
     if (cancelledIcon == null || cancelledIcon.isDisposed()) {
@@ -140,6 +143,7 @@ public class ThinkingBlock extends Composite {
     setExpanded(false);
     unwrapBodyFromScroller();
     state = State.CANCELLED;
+    return true;
   }
 
   /**
@@ -165,6 +169,11 @@ public class ThinkingBlock extends Composite {
   /** True once the block has been completed or cancelled (spinner stopped, final title shown). */
   public boolean isFinalized() {
     return state == State.COMPLETED || state == State.CANCELLED;
+  }
+
+  /** The unique ID for this thinking block, shared with the persistence layer. */
+  public String getThinkingId() {
+    return thinkingId;
   }
 
   /** The full accumulated thinking text streamed so far. */
@@ -272,7 +281,14 @@ public class ThinkingBlock extends Composite {
     if (body == null || body.isDisposed()) {
       return;
     }
-    List<ParsedSection> parsed = parseSections(textBuffer.toString());
+    List<ParsedSection> parsed;
+    try {
+      parsed = parseSections(textBuffer.toString());
+    } catch (RuntimeException e) {
+      // Fallback: render the entire text as a single untitled section rather than crashing the chat view.
+      CopilotCore.LOGGER.error("Failed to parse thinking sections", e);
+      parsed = List.of(new ParsedSection(null, textBuffer.toString()));
+    }
 
     // Sections are append-only: titles never change and new ones are appended at the tail. Update existing
     // bodies in place and create widgets only for newly parsed sections.
@@ -348,7 +364,9 @@ public class ThinkingBlock extends Composite {
     while (matcher.find()) {
       // Preserve the body's original whitespace (e.g. leading indentation for code blocks); only strip the
       // trailing newline(s) that visually separate the body from the upcoming title delimiter.
-      String body = stripTrailingNewlines(raw.substring(cursor, matcher.start()));
+      String body = cursor <= matcher.start()
+          ? stripTrailingNewlines(raw.substring(cursor, matcher.start()))
+          : "";
       if (currentTitle != null || !body.isBlank()) {
         result.add(new ParsedSection(currentTitle, body));
       }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -60,7 +60,8 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
    * Must be called on the UI thread.
    */
   public void appendThinking(Thinking thinking) {
-    if (thinking == null || StringUtils.isBlank(thinking.text())) {
+    // Preserve whitespace-only thinking fragments; they can carry markdown boundaries between sections.
+    if (thinking == null || StringUtils.isEmpty(thinking.text())) {
       return;
     }
     if (isDisposed()) {
@@ -164,9 +165,8 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
       if (active.currentBlock != null && !active.currentBlock.isDisposed()
           && !active.currentBlock.isFinalized()) {
         boolean cancelled = active.currentBlock.showCancelled();
-        if (cancelled) {
-          String cancelTurnId = active.persistTurnId != null ? active.persistTurnId : active.turnId;
-          active.cancelThinkingBlock(cancelTurnId, active.currentBlock.getThinkingId());
+        if (cancelled && active.persistTurnId != null) {
+          active.cancelThinkingBlock(active.persistTurnId, active.currentBlock.getThinkingId());
         }
         active.requestLayout();
       }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -11,6 +11,7 @@ import com.microsoft.copilot.eclipse.core.CopilotCore;
 import com.microsoft.copilot.eclipse.core.lsp.CopilotLanguageServerConnection;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.GenerateThinkingTitleParams;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Thinking;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
 import com.microsoft.copilot.eclipse.ui.chat.services.ChatServiceManager;
 import com.microsoft.copilot.eclipse.ui.utils.SwtUtils;
 
@@ -20,6 +21,13 @@ import com.microsoft.copilot.eclipse.ui.utils.SwtUtils;
 public abstract class ThinkingTurnWidget extends BaseTurnWidget {
 
   private ThinkingBlock currentBlock;
+  private String conversationId;
+
+  /**
+   * The server-assigned turn ID for persistence. Needed because widget turnId may not match the
+   * persistence key (e.g. SubagentTurnWidget uses toolCallId + suffix, not the server turn ID).
+   */
+  private String persistTurnId;
 
   /** Construct a turn widget that supports streaming thinking blocks. */
   protected ThinkingTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId,
@@ -30,6 +38,21 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
   @Override
   public ThinkingTurnWidget getActiveTurnWidget() {
     return (ThinkingTurnWidget) super.getActiveTurnWidget();
+  }
+
+  /**
+   * Set the conversation ID and server-assigned turn ID for thinking-block persistence.
+   * Sets on both this widget and the current active widget (if different) so that
+   * sealThinking/cancel work regardless of which widget is active at call time.
+   */
+  public void setConversationContext(String conversationId, String persistTurnId) {
+    this.conversationId = conversationId;
+    this.persistTurnId = persistTurnId;
+    ThinkingTurnWidget active = getActiveTurnWidget();
+    if (active != null && active != this) {
+      active.conversationId = conversationId;
+      active.persistTurnId = persistTurnId;
+    }
   }
 
   /**
@@ -58,7 +81,7 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
 
   /**
    * Seal the active thinking block and asynchronously fetch a title to finalize it.
-   * Must be called on the UI thread.
+   * Must be called on the UI thread. Requires {@link #setConversationContext} to have been called first.
    */
   public void sealThinking() {
     if (isDisposed()) {
@@ -66,6 +89,9 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
     }
     ThinkingTurnWidget active = getActiveTurnWidget();
     if (active == null || active.isDisposed()) {
+      return;
+    }
+    if (active.persistTurnId == null) {
       return;
     }
     ThinkingBlock target = active.currentBlock;
@@ -81,18 +107,18 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
       return;
     }
     CopilotLanguageServerConnection ls = CopilotCore.getPlugin().getCopilotLanguageServer();
+    target.markSealed();
     if (ls == null) {
-      target.markSealed();
       target.showCompleted();
       requestLayout();
       return;
     }
-    target.markSealed();
     String[] titles = target.getExtractedTitles();
     // Server schema rejects null entries inside extractedTitles, so we send one of the two fields, never both.
     boolean hasTitles = titles.length > 0;
     GenerateThinkingTitleParams params = new GenerateThinkingTitleParams(hasTitles ? null : content,
         hasTitles ? titles : null);
+    String thinkingBlockId = target.getThinkingId();
     ls.generateThinkingTitle(params)
         .thenAccept(resp -> SwtUtils.invokeOnDisplayThread(() -> {
           if (isDisposed() || target.isDisposed() || target.isFinalized()) {
@@ -100,6 +126,7 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
           }
           if (resp != null && StringUtils.isNotBlank(resp.title())) {
             target.setTitle(resp.title());
+            persistThinkingTitle(active.conversationId, active.persistTurnId, thinkingBlockId, resp.title());
           }
           target.showCompleted();
           requestLayout();
@@ -115,16 +142,71 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
         });
   }
 
+  /** Returns the active thinking block ID for persistence context, or {@code null} if none exists. */
+  public String getActiveThinkingBlockId() {
+    ThinkingTurnWidget active = getActiveTurnWidget();
+    if (active == null || active.isDisposed() || active.currentBlock == null || active.currentBlock.isDisposed()) {
+      return null;
+    }
+    return active.currentBlock.getThinkingId();
+  }
+
   @Override
   protected void onChatMessageCancelled() {
     SwtUtils.invokeOnDisplayThreadAsync(() -> {
       if (isDisposed()) {
         return;
       }
-      if (currentBlock != null && !currentBlock.isDisposed() && !currentBlock.isFinalized()) {
-        currentBlock.showCancelled();
-        requestLayout();
+      ThinkingTurnWidget active = getActiveTurnWidget();
+      if (active == null || active.isDisposed()) {
+        return;
+      }
+      if (active.currentBlock != null && !active.currentBlock.isDisposed()
+          && !active.currentBlock.isFinalized()) {
+        boolean cancelled = active.currentBlock.showCancelled();
+        if (cancelled) {
+          String cancelTurnId = active.persistTurnId != null ? active.persistTurnId : active.turnId;
+          active.cancelThinkingBlock(cancelTurnId, active.currentBlock.getThinkingId());
+        }
+        active.requestLayout();
       }
     }, this);
+  }
+
+  private void cancelThinkingBlock(String cancelTurnId, String thinkingBlockId) {
+    if (conversationId == null || serviceManager == null) {
+      return;
+    }
+    serviceManager.getPersistenceManager()
+        .cancelThinkingBlock(conversationId, cancelTurnId, thinkingBlockId);
+  }
+
+  private void persistThinkingTitle(String conversationId, String persistTurnId, String thinkingBlockId, String title) {
+    if (conversationId == null || serviceManager == null) {
+      return;
+    }
+    serviceManager.getPersistenceManager()
+        .updateThinkingBlockTitle(conversationId, persistTurnId, thinkingBlockId, title);
+  }
+
+  /**
+   * Restore a completed thinking block from persisted data. Creates a ThinkingBlock that is
+   * already in the completed state with the given content and title.
+   */
+  public void restoreThinkingBlock(ThinkingBlockData data) {
+    if (isDisposed() || data == null || StringUtils.isBlank(data.getContent())) {
+      return;
+    }
+    ThinkingBlock block = new ThinkingBlock(this, SWT.NONE);
+    block.appendText(data.getContent());
+    if (data.isCancelled()) {
+      block.showCancelled();
+    } else {
+      block.markSealed();
+      if (StringUtils.isNotBlank(data.getTitle())) {
+        block.setTitle(data.getTitle());
+      }
+      block.showCompleted();
+    }
   }
 }

--- a/test-plans/thinking-persistence/thinking-persistence.md
+++ b/test-plans/thinking-persistence/thinking-persistence.md
@@ -1,0 +1,141 @@
+# Thinking Block Persistence & Restoration
+
+## Overview
+Thinking blocks (the collapsible "Thinking" banners shown during model reasoning) are persisted to conversation history so they survive session switches and history restoration. This covers content, state (completed/cancelled), and generated titles for both main agent and subagent thinking blocks.
+
+---
+
+## Test Cases
+
+### TC-001: Completed thinking restores after session switch
+
+**Type:** `Happy Path`
+**Priority:** `P0`
+
+#### Preconditions
+- Copilot chat is open in Agent mode
+- A model that supports thinking is selected (e.g. Claude Sonnet 4.6)
+
+#### Steps
+1. Send a message that triggers thinking (e.g. "think about what improvements this file needs")
+2. Wait for thinking to complete (spinner stops, title appears on the thinking block header)
+3. Open chat history, select a different conversation (or "New Chat")
+4. Open chat history again, select the original conversation
+
+#### Expected Result
+The thinking block appears collapsed with its generated title, expandable to show full thinking content.
+
+#### 📸 Key Screenshots
+- [ ] **Before switch** — Thinking block with title visible in completed state
+- [ ] **After restore** — Same thinking block restored with title and expandable content
+
+---
+
+### TC-002: Cancelled thinking restores after session switch
+
+**Type:** `Happy Path`
+**Priority:** `P0`
+
+#### Preconditions
+- Copilot chat is open in Agent mode
+- A model that supports thinking is selected
+
+#### Steps
+1. Send a message that triggers thinking
+2. While thinking is streaming (spinner active), click Cancel
+3. Verify the thinking block shows cancelled icon
+4. Open chat history, select a different conversation
+5. Open chat history again, select the original conversation
+
+#### Expected Result
+The cancelled thinking block restores with cancelled state and partial content visible on expand.
+
+#### 📸 Key Screenshots
+- [ ] **After cancel** — Thinking block with cancelled icon
+- [ ] **After restore** — Same cancelled thinking block restored
+
+---
+
+### TC-003: Multiple thinking blocks in one turn
+
+**Type:** `Happy Path`
+**Priority:** `P0`
+
+#### Preconditions
+- Copilot chat is open in Agent mode
+- A model that supports thinking is selected
+
+#### Steps
+1. Send a message that triggers multiple rounds of thinking interleaved with tool calls (e.g. a complex multi-step task)
+2. Wait for the full response to complete
+3. Verify multiple thinking blocks are shown, each with its own title
+4. Open chat history, select a different conversation and switch back
+
+#### Expected Result
+All thinking blocks restore in correct order, each with its own title and content, positioned before their corresponding tool calls.
+
+#### 📸 Key Screenshots
+- [ ] **Before switch** — Multiple thinking blocks visible in the turn
+- [ ] **After restore** — All thinking blocks restored in correct positions
+
+---
+
+### TC-004: Subagent thinking restores after session switch
+
+**Type:** `Happy Path`
+**Priority:** `P1`
+
+#### Preconditions
+- Copilot chat is open in Agent mode
+- A model that supports thinking and subagents is selected
+
+#### Steps
+1. Send a message that triggers a subagent with thinking (e.g. "use the test agent to analyze this file step by step")
+2. Wait for the subagent to complete with thinking
+3. Verify the subagent's thinking block appears inside the subagent message block
+4. Open chat history, select a different conversation and switch back
+
+#### Expected Result
+The subagent's thinking block restores inside the subagent message block with title and content.
+
+#### 📸 Key Screenshots
+- [ ] **Before switch** — Subagent thinking block visible inside subagent block
+- [ ] **After restore** — Subagent thinking block restored correctly
+
+---
+
+### TC-005: Cancelled subagent thinking persists
+
+**Type:** `Edge Case`
+**Priority:** `P1`
+
+#### Preconditions
+- Copilot chat is open in Agent mode
+- A model that supports thinking and subagents is selected
+
+#### Steps
+1. Send a message that triggers a subagent
+2. While the subagent is thinking (spinner active inside subagent block), click Cancel
+3. Verify the subagent thinking shows cancelled state
+4. Open chat history, select a different conversation and switch back
+
+#### Expected Result
+The cancelled subagent thinking block restores with cancelled state.
+
+#### 📸 Key Screenshots
+- [ ] **After cancel** — Subagent thinking block with cancelled icon
+- [ ] **After restore** — Cancelled subagent thinking block restored
+
+## Screenshots Checklist
+> Consolidated list of all key screenshot moments.
+
+- [ ] `TC-001` Completed thinking before switch
+- [ ] `TC-001` Completed thinking after restore
+- [ ] `TC-002` Cancelled thinking after cancel
+- [ ] `TC-002` Cancelled thinking after restore
+- [ ] `TC-003` Multiple thinking blocks before switch
+- [ ] `TC-003` Multiple thinking blocks after restore
+- [ ] `TC-004` Subagent thinking before switch
+- [ ] `TC-004` Subagent thinking after restore
+- [ ] `TC-005` Cancelled subagent thinking after cancel
+- [ ] `TC-005` Cancelled subagent thinking after restore


### PR DESCRIPTION
resolve https://github.com/microsoft/copilot-for-eclipse/issues/201
## Change 1: Persist thinking blocks to conversation history

Persist thinking block content, state, and title so thinking blocks can be restored when switching sessions or loading conversation history.

## Data Model

- Add `ThinkingBlockData` with `id`, `content`, `title`, and `state` fields.
- Add `ThinkingBlockState` enum for `COMPLETED` and `CANCELLED`.
- Add `thinkingBlock` to `EditAgentRoundData` so thinking content is stored with the agent round it belongs to.
- Use a UI-generated thinking block ID as the stable identity for title/cancel updates instead of relying on server thinking IDs or round IDs.

## Persistence

- Accumulate thinking stream fragments directly into a thinking block attached to an edit-agent round.
- Create a placeholder edit-agent round when thinking arrives before the corresponding `AgentRound`.
- When the real `AgentRound` arrives, merge it into the placeholder by matching the UI-generated thinking block ID.
- Update thinking titles by `thinkingBlockId`.
- Update cancelled thinking state by `thinkingBlockId`.
- Keep placeholder round IDs as a synthetic sentinel (`-1`) until the real server round arrives.

## UI

- Generate a stable thinking block ID in `ThinkingBlock`.
- Add `setConversationContext(conversationId, persistTurnId)` to route persistence context to the active widget, including subagent widgets.
- `sealThinking()` uses stored context and persists generated titles by thinking block ID.
- `onChatMessageCancelled()` routes through `getActiveTurnWidget()` so subagent thinking cancellation is handled correctly.
- `ChatContentViewer` caches the active thinking block ID per turn while processing progress events, so `ChatView` can pass the correct ID to persistence without querying widget state again.
- Sync `conversationId` to `ChatContentViewer` on begin events.

## Restore

- Restore thinking blocks from persisted `EditAgentRoundData.thinkingBlock`.
- Restore main-agent thinking blocks before their corresponding round reply/tool calls.
- Restore subagent thinking blocks inside the subagent message block.
- Preserve completed/cancelled state, generated title, and full thinking content.

## Validation

- Added persistence coverage for thinking content, title updates, cancellation, and placeholder round merging.
- Added parser regression coverage for adjacent thinking section titles.
- Added manual test plans


## Change 2: Fix ThinkingBlock.parseSections crash on adjacent titles

When two bold title patterns (e.g. **Title1** immediately followed by **Title2**) appear with no body text between them, the newline-skipping logic advances the cursor past the next match's start position, causing a StringIndexOutOfBoundsException. This crashes the entire conversation restore and leaves the chat panel broken.

Fix: guard the substring call with a cursor <= matcher.start() check, producing an empty body when titles are adjacent.
Stack trace:
```
java.lang.StringIndexOutOfBoundsException: Range [45, 44) out of bounds for length 2694
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4849)
	at java.base/java.lang.String.substring(String.java:2823)
	at com.microsoft.copilot.eclipse.ui.chat.ThinkingBlock.parseSections(ThinkingBlock.java:351)
	at com.microsoft.copilot.eclipse.ui.chat.ThinkingBlock.refreshBody(ThinkingBlock.java:275)
	at com.microsoft.copilot.eclipse.ui.chat.ThinkingBlock.appendText(ThinkingBlock.java:101)
......
```
## Change 3 : Fix Thinking Stream Whitespace Handling

- Preserve whitespace-only thinking stream fragments instead of filtering them with `StringUtils.isBlank`.
- This fixes section parsing when the language server sends a newline as its own thinking fragment before the next `**Title**`.
- Use `StringUtils.isEmpty` for thinking fragments so `null` / empty strings are ignored, while meaningful markdown whitespace such as `"\n"` is preserved.
- Persist the same whitespace-only thinking fragments so restored thinking content matches the live rendered content.

Before: 
<img width="1144" height="1071" alt="image" src="https://github.com/user-attachments/assets/0fe9e6b5-9641-4c83-9944-3a5946f2565c" />
