### PR TITLE
feat: Add supportsReasoningEffortLevel in model utilities and services

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtilsTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtilsTests.java
@@ -158,7 +158,7 @@ class ModelUtilsTests {
 
     CopilotModel autoLower = new CopilotModel();
     autoLower.setModelName("auto");
-    assertTrue(ModelUtils.isAutoModel(autoLower));
+    assertFalse(ModelUtils.isAutoModel(autoLower));
 
     CopilotModel other = new CopilotModel();
     other.setModelName("gpt-5");

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtilsTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtilsTests.java
@@ -4,6 +4,7 @@
 package com.microsoft.copilot.eclipse.ui.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -91,5 +92,78 @@ class ModelUtilsTests {
         new CopilotModelCapabilitiesLimits(null, null, null, null)));
 
     assertEquals("medium", ModelUtils.resolveDefaultReasoningEffort(model));
+  }
+
+  @Test
+  void testResolveDefaultReasoningEffort_returnsNullWhenSupportsReasoningEffortLevelFalse() {
+    CopilotModel model = new CopilotModel();
+    model.setModelFamily("gpt-4o");
+    // efforts list is populated, but the server has not vetted the model as supporting effort selection
+    model.setCapabilities(new CopilotModelCapabilities(
+        new CopilotModelCapabilitiesSupports(false, List.of("low", "medium", "high"), false),
+        new CopilotModelCapabilitiesLimits(null, null, null, null)));
+
+    assertNull(ModelUtils.resolveDefaultReasoningEffort(model));
+  }
+
+  @Test
+  void testSupportsReasoningEffortLevel_trueWhenCapabilityFlagSet() {
+    CopilotModel model = new CopilotModel();
+    model.setModelName("gpt-5");
+    model.setCapabilities(new CopilotModelCapabilities(
+        new CopilotModelCapabilitiesSupports(false, List.of("low", "medium", "high"), true),
+        new CopilotModelCapabilitiesLimits(null, null, null, null)));
+
+    assertTrue(ModelUtils.supportsReasoningEffortLevel(model));
+  }
+
+  @Test
+  void testSupportsReasoningEffortLevel_falseWhenCapabilityFlagUnset() {
+    CopilotModel model = new CopilotModel();
+    model.setModelName("gpt-4o");
+    model.setCapabilities(new CopilotModelCapabilities(
+        new CopilotModelCapabilitiesSupports(false, List.of("low", "medium", "high"), false),
+        new CopilotModelCapabilitiesLimits(null, null, null, null)));
+
+    assertFalse(ModelUtils.supportsReasoningEffortLevel(model));
+  }
+
+  @Test
+  void testSupportsReasoningEffortLevel_falseForAutoModel() {
+    CopilotModel model = new CopilotModel();
+    model.setModelName("Auto");
+    // Even if the server were to advertise the capability, the Auto model routes to other models and does not
+    // own its own effort selection.
+    model.setCapabilities(new CopilotModelCapabilities(
+        new CopilotModelCapabilitiesSupports(false, List.of("low", "medium", "high"), true),
+        new CopilotModelCapabilitiesLimits(null, null, null, null)));
+
+    assertFalse(ModelUtils.supportsReasoningEffortLevel(model));
+  }
+
+  @Test
+  void testSupportsReasoningEffortLevel_falseWhenCapabilitiesMissing() {
+    CopilotModel model = new CopilotModel();
+    model.setModelName("gpt-5");
+
+    assertFalse(ModelUtils.supportsReasoningEffortLevel(model));
+    assertFalse(ModelUtils.supportsReasoningEffortLevel(null));
+  }
+
+  @Test
+  void testIsAutoModel() {
+    CopilotModel auto = new CopilotModel();
+    auto.setModelName("Auto");
+    assertTrue(ModelUtils.isAutoModel(auto));
+
+    CopilotModel autoLower = new CopilotModel();
+    autoLower.setModelName("auto");
+    assertTrue(ModelUtils.isAutoModel(autoLower));
+
+    CopilotModel other = new CopilotModel();
+    other.setModelName("gpt-5");
+    assertFalse(ModelUtils.isAutoModel(other));
+
+    assertFalse(ModelUtils.isAutoModel(null));
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
@@ -429,12 +429,16 @@ public class ModelService extends ChatBaseService {
    * Resolves the reasoning effort that should be sent to the language server for the given model: the user's explicit
    * selection when present, otherwise the inferred client-side default from
    * {@link ModelUtils#resolveDefaultReasoningEffort(CopilotModel)}. Returns {@code null} for models that do not
-   * support reasoning-effort selection or for the special "auto" model.
+   * support reasoning-effort selection (see {@link ModelUtils#supportsReasoningEffortLevel(CopilotModel)}) or for
+   * the special "auto" model.
    *
    * @param model the model that will receive the request
    * @return the effort to send, or {@code null} to omit
    */
   public String resolveEffectiveReasoningEffort(CopilotModel model) {
+    if (!ModelUtils.supportsReasoningEffortLevel(model)) {
+      return null;
+    }
     String selected = getSelectedReasoningEffort(model);
     if (StringUtils.isNotBlank(selected)) {
       return selected;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/ModelHoverContentProvider.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/ModelHoverContentProvider.java
@@ -151,15 +151,12 @@ public class ModelHoverContentProvider implements IDropdownItemHoverProvider {
   }
 
   private void addThinkingEffortSection(Composite parent, Runnable closeRequest) {
-    if (model == null || model.getCapabilities() == null) {
+    if (!ModelUtils.supportsReasoningEffortLevel(model)) {
       return;
     }
     CopilotModelCapabilitiesSupports supports = model.getCapabilities().supports();
-    if (supports == null) {
-      return;
-    }
     List<String> efforts = supports.reasoningEfforts();
-    if (efforts == null || efforts.size() <= 1) {
+    if (efforts == null || efforts.isEmpty()) {
       return;
     }
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
@@ -120,9 +120,10 @@ public class ModelUtils {
   private static List<String> buildSuffixParts(CopilotModel model, String reasoningEffort) {
     List<String> parts = new ArrayList<>();
     addIfNotBlank(parts, getContextWindowText(model));
-    // Only surface a reasoning-effort suffix when the model actually exposes more than one effort level. Models with
-    // zero or a single effort have nothing meaningful for the user to pick, so the suffix would just be noise.
-    if (getSupportedReasoningEfforts(model).size() > 1) {
+    // Only surface a reasoning-effort suffix when the language server has explicitly advertised the model as
+    // supporting selectable effort levels. The server only sets supportsReasoningEffortLevel when the model has
+    // more than one effort level AND is hosted on a compatible endpoint.
+    if (supportsReasoningEffortLevel(model)) {
       addIfNotBlank(parts, formatReasoningEffortLevel(reasoningEffort));
     }
     addIfNotBlank(parts, formatPriceCategory(model.getModelPickerPriceCategory()));
@@ -197,12 +198,16 @@ public class ModelUtils {
 
   /**
     * Returns the default reasoning effort to use when the user has not made a selection. Prefers {@code medium} when
-    * it is supported, falling back to the first entry in the supported list.
+    * it is supported, falling back to the first entry in the supported list. Returns {@code null} when the model
+    * does not surface selectable reasoning effort levels (see {@link #supportsReasoningEffortLevel(CopilotModel)}).
    *
    * @param model the model
    * @return the default effort identifier, or {@code null} when none can be determined
    */
   public static String resolveDefaultReasoningEffort(CopilotModel model) {
+    if (!supportsReasoningEffortLevel(model)) {
+      return null;
+    }
     List<String> efforts = getSupportedReasoningEfforts(model);
     if (efforts.isEmpty()) {
       return null;
@@ -284,5 +289,36 @@ public class ModelUtils {
     }
     List<String> efforts = model.getCapabilities().supports().reasoningEfforts();
     return efforts == null ? List.of() : efforts;
+  }
+
+  /**
+   * Returns whether the model is the special "Auto" model, which dynamically routes requests to other models and
+   * therefore does not expose its own reasoning-effort selection.
+   *
+   * @param model the model
+   * @return {@code true} when the model is the Auto model
+   */
+  public static boolean isAutoModel(CopilotModel model) {
+    return model != null && "Auto".equalsIgnoreCase(model.getModelName());
+  }
+
+  /**
+   * Returns whether the model surfaces selectable reasoning effort levels to the user. The language server only
+   * advertises {@code supportsReasoningEffortLevel = true} when the model has more than one effort level and is
+   * hosted on a compatible endpoint, so this is the canonical gate for the reasoning-effort UI and for sending a
+   * {@code modelInfo.reasoningEffort} payload with chat requests. The Auto model is excluded because it routes to
+   * other models and does not own its own effort selection.
+   *
+   * @param model the model
+   * @return {@code true} when the user can select a reasoning effort for this model
+   */
+  public static boolean supportsReasoningEffortLevel(CopilotModel model) {
+    if (model == null || model.getCapabilities() == null || model.getCapabilities().supports() == null) {
+      return false;
+    }
+    if (isAutoModel(model)) {
+      return false;
+    }
+    return model.getCapabilities().supports().supportsReasoningEffortLevel();
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
@@ -100,7 +100,7 @@ public class ModelUtils {
     if (model.getProviderName() != null) {
       return model.getProviderName();
     }
-    if ("Auto".equals(model.getModelName())) {
+    if (isAutoModel(model)) {
       return Messages.model_billing_multiplier_variable;
     }
     // TODO: Remove this legacy fallback after TBB is officially released.
@@ -299,7 +299,7 @@ public class ModelUtils {
    * @return {@code true} when the model is the Auto model
    */
   public static boolean isAutoModel(CopilotModel model) {
-    return model != null && "Auto".equalsIgnoreCase(model.getModelName());
+    return model != null && "Auto".equals(model.getModelName());
   }
 
   /**


### PR DESCRIPTION
Catch up with CLS to check supportsReasoningEffortLevel before rendering thinking effort selection.

Should align with VSCode:

For example gemini should not have thinking effort:
<img width="713" height="226" alt="image" src="https://github.com/user-attachments/assets/926129f6-4f58-4796-86bf-b6920589678b" />

