### PR TITLE
fix -  thinking block persistence merging distinct agent rounds

### DIFF
--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -130,15 +130,10 @@ public class ConversationDataFactory {
     if (agentRounds == null || agentRounds.isEmpty()) {
       return;
     }
-    boolean thinkingRoundUpdated = false;
     for (AgentRound round : agentRounds) {
-      EditAgentRoundData existingRound = thinkingRoundUpdated
-          ? null : findRoundByThinkingBlockId(reply.getEditAgentRounds(), thinkingBlockId);
-      if (existingRound != null) {
-        thinkingRoundUpdated = true;
-      }
+      EditAgentRoundData existingRound = findRoundById(reply.getEditAgentRounds(), round.getRoundId());
       if (existingRound == null) {
-        existingRound = findRoundById(reply.getEditAgentRounds(), round.getRoundId());
+        existingRound = findThinkingPlaceholderRound(reply.getEditAgentRounds(), thinkingBlockId);
       }
       if (existingRound == null) {
         EditAgentRoundData er = convertAgentRoundToEditAgentRoundData(round);
@@ -345,6 +340,14 @@ public class ConversationDataFactory {
       }
     }
     return null;
+  }
+
+  private EditAgentRoundData findThinkingPlaceholderRound(List<EditAgentRoundData> rounds, String thinkingBlockId) {
+    EditAgentRoundData round = findRoundByThinkingBlockId(rounds, thinkingBlockId);
+    if (round == null || round.getRoundId() != SYNTHETIC_ROUND_ID) {
+      return null;
+    }
+    return round;
   }
 
   private EditAgentRoundData findRoundById(List<EditAgentRoundData> rounds, int roundId) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -343,11 +344,17 @@ public class ConversationDataFactory {
   }
 
   private EditAgentRoundData findThinkingPlaceholderRound(List<EditAgentRoundData> rounds, String thinkingBlockId) {
-    EditAgentRoundData round = findRoundByThinkingBlockId(rounds, thinkingBlockId);
-    if (round == null || round.getRoundId() != SYNTHETIC_ROUND_ID) {
+    if (rounds == null || StringUtils.isBlank(thinkingBlockId)) {
       return null;
     }
-    return round;
+    for (EditAgentRoundData round : rounds) {
+      ThinkingBlockData thinkingBlock = round.getThinkingBlock();
+      if (Objects.equals(round.getRoundId(), SYNTHETIC_ROUND_ID) && thinkingBlock != null
+          && thinkingBlockId.equals(thinkingBlock.getId())) {
+        return round;
+      }
+    }
+    return null;
   }
 
   private EditAgentRoundData findRoundById(List<EditAgentRoundData> rounds, int roundId) {


### PR DESCRIPTION
fix https://github.com/microsoft/copilot-for-eclipse/issues/225

Fixes a conversation history persistence regression where agent rounds could be collapsed into a single persisted round when they shared the same thinking block id.

Previously, after a thinking block was persisted as a synthetic placeholder round, later agent progress events with the same thinkingBlockId(not updated until new thinking block arrived) could keep matching that same round. As a result, multiple distinct roundId were merged together: tool calls accumulated on one round, the round id was overwritten by the latest round, and final reply text could be restored before earlier tool calls.

This change keeps the previous round persistence behavior for normal agent content, and only narrows the thinking-specific merge path:

Match existing agent rounds by roundId first.
 Use thinkingBlockId only to attach the first real agent round to a synthetic thinking placeholder.
 Prevent later distinct agent rounds from being merged through the same thinking block id.
