### PR TITLE
fix - Persist cancelled tool call status when chat is cancelled

### DIFF
--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
@@ -43,6 +43,7 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.Thinking;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.EditAgentRoundData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ToolCallData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockState;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
@@ -312,6 +313,28 @@ class ConversationPersistenceManagerTests {
   }
 
   @Test
+  void testMarkRunningToolCallsCancelledAndPersist_UpdatesOnlyRunningToolCalls() throws Exception {
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    CopilotTurnData copilotTurnData = (CopilotTurnData) conversationData.getTurns().get(1);
+    ToolCallData runningToolCall = createTestToolCallData("tool-1", "running");
+    ToolCallData completedToolCall = createTestToolCallData("tool-2", "completed");
+    EditAgentRoundData roundData = new EditAgentRoundData();
+    roundData.setRoundId(1);
+    roundData.setToolCalls(List.of(runningToolCall, completedToolCall));
+    copilotTurnData.getReply().setEditAgentRounds(List.of(roundData));
+
+    Map<String, ConversationData> cache = getConversationCache();
+    cache.put(conversationId, conversationData);
+
+    persistenceManager.markRunningToolCallsCancelledAndPersist(conversationId).get();
+
+    assertEquals("cancelled", runningToolCall.getStatus());
+    assertEquals("completed", completedToolCall.getStatus());
+    verify(mockPersistenceService).saveConversation(conversationData);
+  }
+
+  @Test
   void testUpdateConversationProgress_NewConversation() throws Exception {
     String conversationId = "00000000-0000-0000-0000-000000000001";
     ChatProgressValue progress = createTestChatProgressValue();
@@ -437,5 +460,20 @@ class ConversationPersistenceManagerTests {
     var field = target.getClass().getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(target, value);
+  }
+
+  private ToolCallData createTestToolCallData(String id, String status) {
+    ToolCallData toolCallData = new ToolCallData();
+    toolCallData.setId(id);
+    toolCallData.setName("run_in_terminal");
+    toolCallData.setProgressMessage("Running command");
+    toolCallData.setStatus(status);
+    return toolCallData;
+  }
+
+  private Map<String, ConversationData> getConversationCache() throws Exception {
+    var cacheField = ConversationPersistenceManager.class.getDeclaredField("conversationCache");
+    cacheField.setAccessible(true);
+    return (Map<String, ConversationData>) cacheField.get(persistenceManager);
   }
 }

--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManagerTests.java
@@ -38,6 +38,7 @@ import com.microsoft.copilot.eclipse.core.AuthStatusManager;
 import com.microsoft.copilot.eclipse.core.logger.CopilotForEclipseLogger;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.AgentRound;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatProgressValue;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatStepStatus;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotModel;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Thinking;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
@@ -317,8 +318,8 @@ class ConversationPersistenceManagerTests {
     String conversationId = "00000000-0000-0000-0000-000000000000";
     ConversationData conversationData = createTestConversationData(conversationId);
     CopilotTurnData copilotTurnData = (CopilotTurnData) conversationData.getTurns().get(1);
-    ToolCallData runningToolCall = createTestToolCallData("tool-1", "running");
-    ToolCallData completedToolCall = createTestToolCallData("tool-2", "completed");
+    ToolCallData runningToolCall = createTestToolCallData("tool-1", ChatStepStatus.RUNNING);
+    ToolCallData completedToolCall = createTestToolCallData("tool-2", ChatStepStatus.COMPLETED);
     EditAgentRoundData roundData = new EditAgentRoundData();
     roundData.setRoundId(1);
     roundData.setToolCalls(List.of(runningToolCall, completedToolCall));
@@ -329,8 +330,28 @@ class ConversationPersistenceManagerTests {
 
     persistenceManager.markRunningToolCallsCancelledAndPersist(conversationId).get();
 
-    assertEquals("cancelled", runningToolCall.getStatus());
-    assertEquals("completed", completedToolCall.getStatus());
+    assertEquals(ChatStepStatus.CANCELLED, runningToolCall.getStatus());
+    assertEquals(ChatStepStatus.COMPLETED, completedToolCall.getStatus());
+    verify(mockPersistenceService).saveConversation(conversationData);
+  }
+
+  @Test
+  void testMarkRunningToolCallsCancelledAndPersist_PersistsWhenNoRunningToolCalls() throws Exception {
+    String conversationId = "00000000-0000-0000-0000-000000000000";
+    ConversationData conversationData = createTestConversationData(conversationId);
+    CopilotTurnData copilotTurnData = (CopilotTurnData) conversationData.getTurns().get(1);
+    ToolCallData completedToolCall = createTestToolCallData("tool-1", ChatStepStatus.COMPLETED);
+    EditAgentRoundData roundData = new EditAgentRoundData();
+    roundData.setRoundId(1);
+    roundData.setToolCalls(List.of(completedToolCall));
+    copilotTurnData.getReply().setEditAgentRounds(List.of(roundData));
+
+    Map<String, ConversationData> cache = getConversationCache();
+    cache.put(conversationId, conversationData);
+
+    persistenceManager.markRunningToolCallsCancelledAndPersist(conversationId).get();
+
+    assertEquals(ChatStepStatus.COMPLETED, completedToolCall.getStatus());
     verify(mockPersistenceService).saveConversation(conversationData);
   }
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
@@ -28,6 +28,7 @@ import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.EditAgentR
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ReplyData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockData;
 import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ThinkingBlockState;
+import com.microsoft.copilot.eclipse.core.persistence.CopilotTurnData.ToolCallData;
 import com.microsoft.copilot.eclipse.core.persistence.UserTurnData.MessageData;
 
 /**
@@ -42,6 +43,8 @@ public class ConversationPersistenceManager {
 
   // Maximum number of conversations to keep persisted
   private static final int MAX_PERSISTED_CONVERSATIONS = 256;
+  private static final String TOOL_STATUS_RUNNING = "running";
+  private static final String TOOL_STATUS_CANCELLED = "cancelled";
 
   /**
    * Constructor for ConversationPersistenceManager.
@@ -264,6 +267,43 @@ public class ConversationPersistenceManager {
         }
       } catch (IOException e) {
         CopilotCore.LOGGER.error("Failed to persist cached conversation: " + conversationId, e);
+      } finally {
+        lock.writeLock().unlock();
+      }
+    });
+  }
+
+  /**
+   * Marks cached running tool calls as cancelled, then persists the cached conversation to disk.
+   *
+   * @param conversationId the ID of the cached conversation to persist
+   * @return a future that completes when the cached conversation has been persisted
+   */
+  public CompletableFuture<Void> markRunningToolCallsCancelledAndPersist(String conversationId) {
+    if (StringUtils.isBlank(conversationId)) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    ConversationData conversationData;
+    lock.writeLock().lock();
+    try {
+      conversationData = conversationCache.get(conversationId);
+      if (conversationData == null) {
+        return CompletableFuture.completedFuture(null);
+      }
+      if (!markRunningToolCallsCancelled(conversationData)) {
+        return CompletableFuture.completedFuture(null);
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
+
+    return CompletableFuture.runAsync(() -> {
+      lock.writeLock().lock();
+      try {
+        persistAndCacheConversation(conversationData);
+      } catch (IOException e) {
+        CopilotCore.LOGGER.error("Failed to persist cancelled tool calls for conversation: " + conversationId, e);
       } finally {
         lock.writeLock().unlock();
       }
@@ -496,6 +536,31 @@ public class ConversationPersistenceManager {
   private void persistAndCacheConversation(ConversationData conversation) throws IOException {
     persistenceService.saveConversation(conversation);
     conversationCache.put(conversation.getConversationId(), conversation);
+  }
+
+  private boolean markRunningToolCallsCancelled(ConversationData conversationData) {
+    boolean updated = false;
+    if (conversationData.getTurns() == null) {
+      return false;
+    }
+    for (AbstractTurnData turn : conversationData.getTurns()) {
+      if (!(turn instanceof CopilotTurnData copilotTurnData) || copilotTurnData.getReply() == null
+          || copilotTurnData.getReply().getEditAgentRounds() == null) {
+        continue;
+      }
+      for (EditAgentRoundData round : copilotTurnData.getReply().getEditAgentRounds()) {
+        if (round.getToolCalls() == null) {
+          continue;
+        }
+        for (ToolCallData toolCall : round.getToolCalls()) {
+          if (toolCall != null && TOOL_STATUS_RUNNING.equalsIgnoreCase(toolCall.getStatus())) {
+            toolCall.setStatus(TOOL_STATUS_CANCELLED);
+            updated = true;
+          }
+        }
+      }
+    }
+    return updated;
   }
 
   /**

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
@@ -20,6 +20,7 @@ import org.eclipse.core.resources.IResource;
 import com.microsoft.copilot.eclipse.core.AuthStatusManager;
 import com.microsoft.copilot.eclipse.core.CopilotCore;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatProgressValue;
+import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatStepStatus;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotModel;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.TodoItem;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.Turn;
@@ -43,8 +44,6 @@ public class ConversationPersistenceManager {
 
   // Maximum number of conversations to keep persisted
   private static final int MAX_PERSISTED_CONVERSATIONS = 256;
-  private static final String TOOL_STATUS_RUNNING = "running";
-  private static final String TOOL_STATUS_CANCELLED = "cancelled";
 
   /**
    * Constructor for ConversationPersistenceManager.
@@ -291,9 +290,7 @@ public class ConversationPersistenceManager {
       if (conversationData == null) {
         return CompletableFuture.completedFuture(null);
       }
-      if (!markRunningToolCallsCancelled(conversationData)) {
-        return CompletableFuture.completedFuture(null);
-      }
+      markRunningToolCallsCancelled(conversationData);
     } finally {
       lock.writeLock().unlock();
     }
@@ -538,10 +535,9 @@ public class ConversationPersistenceManager {
     conversationCache.put(conversation.getConversationId(), conversation);
   }
 
-  private boolean markRunningToolCallsCancelled(ConversationData conversationData) {
-    boolean updated = false;
+  private void markRunningToolCallsCancelled(ConversationData conversationData) {
     if (conversationData.getTurns() == null) {
-      return false;
+      return;
     }
     for (AbstractTurnData turn : conversationData.getTurns()) {
       if (!(turn instanceof CopilotTurnData copilotTurnData) || copilotTurnData.getReply() == null
@@ -553,14 +549,12 @@ public class ConversationPersistenceManager {
           continue;
         }
         for (ToolCallData toolCall : round.getToolCalls()) {
-          if (toolCall != null && TOOL_STATUS_RUNNING.equalsIgnoreCase(toolCall.getStatus())) {
-            toolCall.setStatus(TOOL_STATUS_CANCELLED);
-            updated = true;
+          if (toolCall != null && ChatStepStatus.RUNNING.equalsIgnoreCase(toolCall.getStatus())) {
+            toolCall.setStatus(ChatStepStatus.CANCELLED);
           }
         }
       }
     }
-    return updated;
   }
 
   /**

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
@@ -1281,7 +1281,7 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
     this.lastRunSubagentToolCallId = null;
 
     if (persistenceManager != null && StringUtils.isNotBlank(this.conversationId)) {
-      persistenceManager.persistCachedConversation(this.conversationId);
+      persistenceManager.markRunningToolCallsCancelledAndPersist(this.conversationId);
     }
     conversationFutures.forEach(future -> {
       future.cancel(false);


### PR DESCRIPTION
## Summary

Fixes microsoft/copilot-for-eclipse#239.

When a chat response is cancelled while an agent tool call is still running, the live UI shows the tool as cancelled, but the cached conversation can still persist that tool call with `running` status. Restoring the conversation later reads that persisted status and shows the tool call as running/spinning again.

This change marks cached `running` tool calls as `cancelled` before persisting the conversation during the chat cancel flow.

## Changes

- Add persistence handling to convert cached running tool calls to cancelled on chat cancel.
- Keep the fix scoped to the conversation persistence model, instead of changing confirmation dialog or tool skip behavior.
- Add coverage to verify only `running` tool calls are updated while completed tool calls remain unchanged.