### PR TITLE
docs: fix typo in README upgrade recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GitHub Copilot for Eclipse brings AI-assisted coding to the Eclipse IDE with the
 
 Starting from version **0.18.0**, we have added internal support for the upcoming [usage-based billing experience](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/), including experience updates to the usage panel, usage notifications, and model picker. These changes will become visible once usage-based billing is rolled out.
 
-To ensure compatibility with the new billing experience, we strongly recommend upgrading to the plugin to **0.18.0 or later** as soon as possible.
+To ensure compatibility with the new billing experience, we strongly recommend upgrading the plugin to **0.18.0 or later** as soon as possible.
 
 Clients using older plugin versions will continue to function. However, the billing and usage experience may not be optimal and may not accurately reflect the latest usage-based billing experience.
 


### PR DESCRIPTION
## What

Fix a small typo in `README.md` under the **Usage-based billing support** section.

The current wording contains a duplicated `to`:

> we strongly recommend upgrading **to** the plugin **to** **0.18.0 or later** as soon as possible.

This change drops the redundant first `to` so the sentence reads naturally:

> we strongly recommend upgrading the plugin to **0.18.0 or later** as soon as possible.

## Why

The wording was introduced in #227 when the usage-based billing section was added. The duplicated `to` makes the sentence grammatically incorrect and is the first thing users see in the README, so it is worth tightening up.

## Scope

- Single-line, docs-only change. No source, build, test, or behavior is affected.
- No CLA-relevant code change; pure prose fix.

## Verification

- `git diff` shows a one-character (well, three-character) change confined to `README.md`.
- `README.md` still renders correctly as Markdown; no link, list, heading, or code block was touched.


Made with [Cursor](https://cursor.com)