### PR TITLE
fix: refresh scroller layout when tool confirmation dialog is cancelled

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
@@ -649,17 +649,17 @@ public abstract class BaseTurnWidget extends Composite {
       ConfirmationContent content, Object input) {
     reset();
 
-    Runnable refreshLayout = null;
-    Composite ancestor = this.getParent();
-    while (ancestor != null && !ancestor.isDisposed()) {
-      if (ancestor instanceof ChatContentViewer) {
-        final ChatContentViewer viewer = (ChatContentViewer) ancestor;
-        refreshLayout = viewer::refreshScrollerLayout;
-        break;
+    this.confirmDialog = new InvokeToolConfirmationDialog(this, content, input);
+    this.confirmDialog.addDisposeListener(e -> {
+      Composite ancestor = this.getParent();
+      while (ancestor != null && !ancestor.isDisposed()) {
+        if (ancestor instanceof ChatContentViewer) {
+          ((ChatContentViewer) ancestor).requestRefreshScrollerLayout();
+          break;
+        }
+        ancestor = ancestor.getParent();
       }
-      ancestor = ancestor.getParent();
-    }
-    this.confirmDialog = new InvokeToolConfirmationDialog(this, content, input, refreshLayout);
+    });
     CompletableFuture<LanguageModelToolConfirmationResult> toolConfirmationFuture = this.confirmDialog
         .getConfirmationFuture();
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
@@ -649,7 +649,17 @@ public abstract class BaseTurnWidget extends Composite {
       ConfirmationContent content, Object input) {
     reset();
 
-    this.confirmDialog = new InvokeToolConfirmationDialog(this, content, input);
+    Runnable refreshLayout = null;
+    Composite ancestor = this.getParent();
+    while (ancestor != null && !ancestor.isDisposed()) {
+      if (ancestor instanceof ChatContentViewer) {
+        final ChatContentViewer viewer = (ChatContentViewer) ancestor;
+        refreshLayout = viewer::refreshScrollerLayout;
+        break;
+      }
+      ancestor = ancestor.getParent();
+    }
+    this.confirmDialog = new InvokeToolConfirmationDialog(this, content, input, refreshLayout);
     CompletableFuture<LanguageModelToolConfirmationResult> toolConfirmationFuture = this.confirmDialog
         .getConfirmationFuture();
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
@@ -405,6 +405,14 @@ public class ChatContentViewer extends ScrolledComposite {
   }
 
   /**
+   * Schedules a single async {@link #refreshScrollerLayout()} call so that multiple dispose/layout
+   * events that arrive in the same event-loop tick are coalesced into one pass.
+   */
+  public void requestRefreshScrollerLayout() {
+    SwtUtils.invokeOnDisplayThreadAsync(() -> refreshScrollerLayout(), this);
+  }
+
+  /**
    * Update the size of scrolled composite when there are content updates.
    */
   public void refreshScrollerLayout() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
@@ -68,7 +68,6 @@ public class InvokeToolConfirmationDialog extends Composite {
   private Runnable titleFontChangeCallback;
   private ConfirmationContent confirmationContent;
   private ConfirmationAction selectedAction;
-  private final Runnable onCancelCallback;
 
   /**
    * Create a new confirmation dialog driven by {@link ConfirmationContent}.
@@ -76,14 +75,12 @@ public class InvokeToolConfirmationDialog extends Composite {
    * @param parent the parent composite
    * @param content confirmation content with title, message, and action buttons
    * @param input the input object to pass to the tool
-   * @param onCancelCallback invoked after the dialog is disposed on cancellation, for layout refresh
    */
   public InvokeToolConfirmationDialog(Composite parent,
-      ConfirmationContent content, Object input, Runnable onCancelCallback) {
+      ConfirmationContent content, Object input) {
     super(parent, SWT.BORDER | SWT.WRAP);
     this.setLayout(new GridLayout(1, false));
     this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-    this.onCancelCallback = onCancelCallback;
 
     this.confirmationContent = content;
     createDialogContent(content.getTitle(), content.getMessage(), input);
@@ -122,10 +119,7 @@ public class InvokeToolConfirmationDialog extends Composite {
             && StringUtils.isNotEmpty(this.cancelMessage)) {
           new AgentToolCancelLabel(parent, SWT.NONE, this.cancelMessage);
         }
-        this.dispose();
-        if (onCancelCallback != null) {
-          onCancelCallback.run();
-        }
+        disposeAndRequestParentLayout();
       }, this);
     }
   }
@@ -321,6 +315,10 @@ public class InvokeToolConfirmationDialog extends Composite {
         new LanguageModelToolConfirmationResult(
             ToolConfirmationResult.ACCEPT));
 
+    disposeAndRequestParentLayout();
+  }
+
+  private void disposeAndRequestParentLayout() {
     Composite parent = this.getParent();
     this.dispose();
     if (parent != null && !parent.isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
@@ -68,6 +68,7 @@ public class InvokeToolConfirmationDialog extends Composite {
   private Runnable titleFontChangeCallback;
   private ConfirmationContent confirmationContent;
   private ConfirmationAction selectedAction;
+  private final Runnable onCancelCallback;
 
   /**
    * Create a new confirmation dialog driven by {@link ConfirmationContent}.
@@ -75,12 +76,14 @@ public class InvokeToolConfirmationDialog extends Composite {
    * @param parent the parent composite
    * @param content confirmation content with title, message, and action buttons
    * @param input the input object to pass to the tool
+   * @param onCancelCallback invoked after the dialog is disposed on cancellation, for layout refresh
    */
   public InvokeToolConfirmationDialog(Composite parent,
-      ConfirmationContent content, Object input) {
+      ConfirmationContent content, Object input, Runnable onCancelCallback) {
     super(parent, SWT.BORDER | SWT.WRAP);
     this.setLayout(new GridLayout(1, false));
     this.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+    this.onCancelCallback = onCancelCallback;
 
     this.confirmationContent = content;
     createDialogContent(content.getTitle(), content.getMessage(), input);
@@ -120,8 +123,8 @@ public class InvokeToolConfirmationDialog extends Composite {
           new AgentToolCancelLabel(parent, SWT.NONE, this.cancelMessage);
         }
         this.dispose();
-        if (parent != null && !parent.isDisposed()) {
-          parent.requestLayout();
+        if (onCancelCallback != null) {
+          onCancelCallback.run();
         }
       }, this);
     }


### PR DESCRIPTION
## Summary

- When the user cancels a subagent tool confirmation dialog, the subagent panel stays expanded at its pre-cancel height
- Root cause: `cancelConfirmation()` calls `parent.layout()` (relays the turn widget's children) but never updates the `ScrolledComposite`'s minimum size via `refreshScrollerLayout()`
- On the Continue path this goes unnoticed because subsequent subagent messages trigger a layout refresh; on the Cancel path no further messages arrive, so the panel is stuck

## Fix

Pass a `Runnable` callback from `BaseTurnWidget` into `InvokeToolConfirmationDialog` at construction. `BaseTurnWidget` walks up the ancestor chain once to find `ChatContentViewer` and captures `refreshScrollerLayout()` as the callback. `cancelConfirmation()` calls it after disposal, which recomputes `setMinHeight()` in a single layout pass and collapses the panel correctly. This also removes the redundant `parent.layout()` call that preceded the deep `layout(true,true)` inside `refreshScrollerLayout()`.

## Test plan

- [x] Invoke a subagent (e.g. "run ls /Users/darshanpoudel/Desktop in the terminal")
- [x] Wait for the tool confirmation dialog to appear
- [x] Click **Cancel**
- [x] Verify the subagent panel resizes/collapses correctly and does not stay stuck at the expanded height
- [x] Click **Continue** on a separate invocation and verify that path is unaffected

Fixes #169