### PR TITLE
fix -  nested scrolling and full-row table selection for auto-approve preferences

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/CustomInstructionPreferencePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/CustomInstructionPreferencePage.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
-import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
@@ -269,18 +268,7 @@ public class CustomInstructionPreferencePage extends FieldEditorPreferencePage i
     // Set the file location column to take remaining width (table width - project name column width)
     fileLocationColumn.setWidth(tableGridData.widthHint > 0 ? tableGridData.widthHint - 150 : 400);
 
-    // Add resize listener to make the file location column take remaining width
-    table.addControlListener(new ControlAdapter() {
-      @Override
-      public void controlResized(org.eclipse.swt.events.ControlEvent e) {
-        int tableWidth = table.getClientArea().width;
-        int projectNameWidth = projectNameColumn.getWidth();
-        int remainingWidth = tableWidth - projectNameWidth;
-        if (remainingWidth > 100) { // Minimum width for file location column
-          fileLocationColumn.setWidth(remainingWidth);
-        }
-      }
-    });
+    SwtUtils.resizeColumnToFillTable(table, fileLocationColumn, 100, projectNameColumn);
 
     // Populate table with actual workspace projects
     populateProjectTable(table);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
@@ -23,7 +23,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -179,17 +178,8 @@ public class FileOperationAutoApproveSection extends Composite {
             ? Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY) : null;
       }
     });
-    table.addControlListener(new ControlAdapter() {
-      @Override
-      public void controlResized(org.eclipse.swt.events.ControlEvent e) {
-        int remainingWidth = table.getClientArea().width
-            - patternCol.getColumn().getWidth()
-            - descCol.getColumn().getWidth();
-        if (remainingWidth > 100) {
-          statusCol.getColumn().setWidth(remainingWidth);
-        }
-      }
-    });
+    SwtUtils.resizeColumnToFillTable(table, statusCol.getColumn(), 100,
+        patternCol.getColumn(), descCol.getColumn());
 
     tableViewer.setContentProvider(ArrayContentProvider.getInstance());
     tableViewer.addSelectionChangedListener(e -> updateButtonState());

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -112,13 +113,14 @@ public class FileOperationAutoApproveSection extends Composite {
 
   private void createTable(Composite parent) {
     tableViewer = new TableViewer(parent,
-        SWT.BORDER | SWT.FULL_SELECTION | SWT.SINGLE);
+        SWT.BORDER | SWT.FULL_SELECTION | SWT.SINGLE | SWT.V_SCROLL);
     Table table = tableViewer.getTable();
     GridData tableData = new GridData(SWT.FILL, SWT.FILL, true, false);
     tableData.heightHint = TABLE_HEIGHT_HINT;
     table.setLayoutData(tableData);
     table.setHeaderVisible(true);
     table.setLinesVisible(true);
+    SwtUtils.forwardVerticalMouseWheelToParentScrollerAtBoundary(table);
 
     TableViewerColumn patternCol =
         new TableViewerColumn(tableViewer, SWT.NONE);
@@ -175,6 +177,17 @@ public class FileOperationAutoApproveSection extends Composite {
       public Color getForeground(Object element) {
         return ((FileOperationAutoApproveRule) element).isDefault()
             ? Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY) : null;
+      }
+    });
+    table.addControlListener(new ControlAdapter() {
+      @Override
+      public void controlResized(org.eclipse.swt.events.ControlEvent e) {
+        int remainingWidth = table.getClientArea().width
+            - patternCol.getColumn().getWidth()
+            - descCol.getColumn().getWidth();
+        if (remainingWidth > 100) {
+          statusCol.getColumn().setWidth(remainingWidth);
+        }
       }
     });
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpAutoApproveSection.java
@@ -90,10 +90,11 @@ public class McpAutoApproveSection extends Composite {
 
     // Tree viewer for server/tool approval
     treeViewer = new CheckboxTreeViewer(group,
-        SWT.BORDER | SWT.FULL_SELECTION);
+        SWT.BORDER | SWT.FULL_SELECTION | SWT.V_SCROLL);
     GridData treeData = new GridData(SWT.FILL, SWT.FILL, true, false);
     treeData.heightHint = TREE_HEIGHT_HINT;
     treeViewer.getTree().setLayoutData(treeData);
+    SwtUtils.forwardVerticalMouseWheelToParentScrollerAtBoundary(treeViewer.getTree());
 
     treeViewer.setContentProvider(new McpTreeContentProvider());
     treeViewer.setLabelProvider(new McpTreeLabelProvider());

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -30,6 +31,7 @@ import com.microsoft.copilot.eclipse.core.Constants;
 import com.microsoft.copilot.eclipse.core.CopilotCore;
 import com.microsoft.copilot.eclipse.core.chat.TerminalAutoApproveRule;
 import com.microsoft.copilot.eclipse.ui.chat.confirmation.TerminalConfirmationHandler;
+import com.microsoft.copilot.eclipse.ui.utils.SwtUtils;
 
 /**
  * Terminal auto-approve section with a rule table, action buttons, and
@@ -90,13 +92,14 @@ public class TerminalAutoApproveSection extends Composite {
 
   private void createTable(Composite parent) {
     tableViewer = new TableViewer(parent,
-        SWT.BORDER | SWT.FULL_SELECTION | SWT.SINGLE);
+        SWT.BORDER | SWT.FULL_SELECTION | SWT.SINGLE | SWT.V_SCROLL);
     Table table = tableViewer.getTable();
     GridData tableData = new GridData(SWT.FILL, SWT.FILL, true, false);
     tableData.heightHint = TABLE_HEIGHT_HINT;
     table.setLayoutData(tableData);
     table.setHeaderVisible(true);
     table.setLinesVisible(true);
+    SwtUtils.forwardVerticalMouseWheelToParentScrollerAtBoundary(table);
 
     TableViewerColumn commandCol =
         new TableViewerColumn(tableViewer, SWT.NONE);
@@ -121,6 +124,16 @@ public class TerminalAutoApproveSection extends Composite {
         return ((TerminalAutoApproveRule) element).isAutoApprove()
             ? Messages.preferences_page_auto_approve_allow
             : Messages.preferences_page_auto_approve_deny;
+      }
+    });
+    table.addControlListener(new ControlAdapter() {
+      @Override
+      public void controlResized(org.eclipse.swt.events.ControlEvent e) {
+        int remainingWidth = table.getClientArea().width
+            - commandCol.getColumn().getWidth();
+        if (remainingWidth > 100) {
+          statusCol.getColumn().setWidth(remainingWidth);
+        }
       }
     });
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
@@ -18,7 +18,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -126,16 +125,8 @@ public class TerminalAutoApproveSection extends Composite {
             : Messages.preferences_page_auto_approve_deny;
       }
     });
-    table.addControlListener(new ControlAdapter() {
-      @Override
-      public void controlResized(org.eclipse.swt.events.ControlEvent e) {
-        int remainingWidth = table.getClientArea().width
-            - commandCol.getColumn().getWidth();
-        if (remainingWidth > 100) {
-          statusCol.getColumn().setWidth(remainingWidth);
-        }
-      }
-    });
+    SwtUtils.resizeColumnToFillTable(table, statusCol.getColumn(), 100,
+        commandCol.getColumn());
 
     tableViewer.setContentProvider(ArrayContentProvider.getInstance());
     tableViewer.addSelectionChangedListener(e -> updateButtonState());

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
@@ -12,14 +12,20 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.ScrollBar;
+import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
@@ -270,6 +276,69 @@ public class SwtUtils {
    */
   public static Color getDefaultGhostTextColor(Display display) {
     return new Color(display, new RGB(DEFAULT_GHOST_TEXT_SCALE, DEFAULT_GHOST_TEXT_SCALE, DEFAULT_GHOST_TEXT_SCALE));
+  }
+
+  /**
+   * Forwards vertical mouse wheel scrolling from a nested scrollable to its nearest parent scroller when the nested
+   * control is already at the scroll boundary.
+   */
+  public static void forwardVerticalMouseWheelToParentScrollerAtBoundary(Scrollable scrollable) {
+    scrollable.addListener(SWT.MouseWheel, event -> {
+      if (event.count == 0 || scrollable.isDisposed()
+          || canScrollVertically(scrollable.getVerticalBar(), event.count)) {
+        return;
+      }
+
+      ScrolledComposite parentScroller = findParentScroller(scrollable);
+      if (parentScroller != null
+          && canScrollVertically(parentScroller.getVerticalBar(), event.count)) {
+        event.doit = false;
+        scrollParentVertically(parentScroller, event.count);
+      }
+    });
+  }
+
+  private static ScrolledComposite findParentScroller(Scrollable scrollable) {
+    Composite parent = scrollable.getParent();
+    while (parent != null) {
+      if (parent instanceof ScrolledComposite scrolledComposite) {
+        return scrolledComposite;
+      }
+      parent = parent.getParent();
+    }
+    return null;
+  }
+
+  private static void scrollParentVertically(ScrolledComposite scrolledComposite, int wheelCount) {
+    ScrollBar verticalBar = scrolledComposite.getVerticalBar();
+    if (verticalBar == null || verticalBar.isDisposed()) {
+      return;
+    }
+
+    Point origin = scrolledComposite.getOrigin();
+    int minimum = verticalBar.getMinimum();
+    int maximum = Math.max(minimum,
+        verticalBar.getMaximum() - verticalBar.getThumb());
+    int delta = -wheelCount * Math.max(1, verticalBar.getIncrement());
+    int nextY = Math.max(minimum, Math.min(maximum, origin.y + delta));
+    scrolledComposite.setOrigin(origin.x, nextY);
+  }
+
+  private static boolean canScrollVertically(ScrollBar verticalBar, int wheelCount) {
+    if (verticalBar == null || verticalBar.isDisposed()
+        || !verticalBar.getEnabled()) {
+      return false;
+    }
+
+    int minimum = verticalBar.getMinimum();
+    int maximum = Math.max(minimum,
+        verticalBar.getMaximum() - verticalBar.getThumb());
+    int selection = Math.max(minimum,
+        Math.min(maximum, verticalBar.getSelection()));
+    if (wheelCount > 0) {
+      return selection > minimum;
+    }
+    return selection < maximum;
   }
 
   /**

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
@@ -18,6 +18,8 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.events.ControlAdapter;
+import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
@@ -27,6 +29,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -339,6 +343,25 @@ public class SwtUtils {
       return selection > minimum;
     }
     return selection < maximum;
+  }
+
+  /**
+   * Resizes a table column to fill the table client area not occupied by the fixed-width columns.
+   */
+  public static void resizeColumnToFillTable(Table table, TableColumn fillColumn,
+      int minWidth, TableColumn... fixedColumns) {
+    table.addControlListener(new ControlAdapter() {
+      @Override
+      public void controlResized(ControlEvent e) {
+        int remainingWidth = table.getClientArea().width;
+        for (TableColumn fixedColumn : fixedColumns) {
+          remainingWidth -= fixedColumn.getWidth();
+        }
+        if (remainingWidth > minWidth) {
+          fillColumn.setWidth(remainingWidth);
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Forward vertical mouse wheel events from auto-approve inner viewers to the parent preference scroller only after the inner viewer reaches its scroll boundary
- Update auto-approve tables so the last column fills remaining table width, matching the custom instructions table behavior