### PR TITLE
fix: Request layout update after setting markup in AgentStatusLabel

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentStatusLabel.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentStatusLabel.java
@@ -142,6 +142,7 @@ public class AgentStatusLabel extends Composite {
       AccessibilityUtils.addFocusBorderToComposite(styledText);
     }
     textLabel.setMarkup(text);
+    this.requestLayout();
   }
 
   private enum Status {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
@@ -436,7 +436,6 @@ public class ChatContentViewer extends ScrolledComposite {
 
     this.setMinHeight(contentHeight);
     this.setMinWidth(containerSize.x);
-    this.layout(true, true);
   }
 
   /**


### PR DESCRIPTION
1. `setMinSize` already called layout, force layout in `refreshScrollerLayout` after `setMinSize` is expensive and redundant, should be removed.
2. `AgentStatusLabel` should requestLayout after text changes.