### PR TITLE
[Feat] Read the default text editor preferences from platform instead of defaulting to spaces.

### DIFF
--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/completion/FormatOptionProviderTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/completion/FormatOptionProviderTests.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +27,11 @@ class FormatOptionProviderTests {
   private IFile mockFile;
   private IProject mockProject;
 
+  private static final String EDITOR_PREF_NODE = "org.eclipse.ui.editors";
+  private static final String TAB_WIDTH_KEY = "tabWidth";
+  private static final String SPACES_FOR_TABS_KEY = "spacesForTabs";
   private static final int PREFERENCE_DEFAULT_TAB_SIZE = 4;
+  private static final boolean PREFERENCE_DEFAULT_USE_SPACE = true;
 
   @BeforeEach
   void setUp() {
@@ -56,16 +62,38 @@ class FormatOptionProviderTests {
   void testGetCopilotDefaultTabCharAndSizeForUnknownLanguage() {
     when(mockFile.getFileExtension()).thenReturn("js");
 
-    assertTrue(formatOptionProvider.useSpace(mockFile));
-    assertEquals(PREFERENCE_DEFAULT_TAB_SIZE, formatOptionProvider.getTabSize(mockFile));
+    FormattingOptions expectedFormattingOptions = getEclipseTextEditorFormattingOptions();
+    assertEquals(expectedFormattingOptions.isInsertSpaces(), formatOptionProvider.useSpace(mockFile));
+    assertEquals(expectedFormattingOptions.getTabSize(), formatOptionProvider.getTabSize(mockFile));
   }
 
   @Test
   void testGetCopilotDefaultTabCharAndSizeForNoExtensionFile() {
     when(mockFile.getFileExtension()).thenReturn(null);
 
-    assertTrue(formatOptionProvider.useSpace(mockFile));
-    assertEquals(PREFERENCE_DEFAULT_TAB_SIZE, formatOptionProvider.getTabSize(mockFile));
+    FormattingOptions expectedFormattingOptions = getEclipseTextEditorFormattingOptions();
+    assertEquals(expectedFormattingOptions.isInsertSpaces(), formatOptionProvider.useSpace(mockFile));
+    assertEquals(expectedFormattingOptions.getTabSize(), formatOptionProvider.getTabSize(mockFile));
   }
 
+  private FormattingOptions getEclipseTextEditorFormattingOptions() {
+    try {
+      IPreferencesService service = Platform.getPreferencesService();
+      boolean useSpaces = service.getBoolean(
+          EDITOR_PREF_NODE,
+          SPACES_FOR_TABS_KEY,
+          PREFERENCE_DEFAULT_USE_SPACE,
+          null
+      );
+      int tabSize = service.getInt(
+          EDITOR_PREF_NODE,
+          TAB_WIDTH_KEY,
+          PREFERENCE_DEFAULT_TAB_SIZE,
+          null
+      );
+      return new FormattingOptions(tabSize, useSpaces);
+    } catch (Exception e) {
+      return new FormattingOptions(PREFERENCE_DEFAULT_TAB_SIZE, PREFERENCE_DEFAULT_USE_SPACE);
+    }
+  }
 }

--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/completion/FormatOptionProviderTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/completion/FormatOptionProviderTests.java
@@ -10,12 +10,15 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.IPreferencesService;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.copilot.eclipse.core.format.FormatOptionProvider;
@@ -30,8 +33,6 @@ class FormatOptionProviderTests {
   private static final String EDITOR_PREF_NODE = "org.eclipse.ui.editors";
   private static final String TAB_WIDTH_KEY = "tabWidth";
   private static final String SPACES_FOR_TABS_KEY = "spacesForTabs";
-  private static final int PREFERENCE_DEFAULT_TAB_SIZE = 4;
-  private static final boolean PREFERENCE_DEFAULT_USE_SPACE = true;
 
   @BeforeEach
   void setUp() {
@@ -58,42 +59,20 @@ class FormatOptionProviderTests {
     assertEquals(tabSize, formatOptionProvider.getTabSize(mockFile));
   }
 
-  @Test
-  void testGetCopilotDefaultTabCharAndSizeForUnknownLanguage() {
-    when(mockFile.getFileExtension()).thenReturn("js");
+  @ParameterizedTest @NullSource @ValueSource(strings = { "js" })
+  void testUsesEclipseTextEditorFormattingOptionsForUnknownOrNoExtension(String extension) {
+    when(mockFile.getFileExtension()).thenReturn(extension);
 
-    FormattingOptions expectedFormattingOptions = getEclipseTextEditorFormattingOptions();
-    assertEquals(expectedFormattingOptions.isInsertSpaces(), formatOptionProvider.useSpace(mockFile));
-    assertEquals(expectedFormattingOptions.getTabSize(), formatOptionProvider.getTabSize(mockFile));
+    // Set the Eclipse preferences to be something other than the default (false, 4)
+    setEditorFormattingPreferences(true, 2);
+
+    assertTrue(formatOptionProvider.useSpace(mockFile));
+    assertEquals(2, formatOptionProvider.getTabSize(mockFile));
   }
 
-  @Test
-  void testGetCopilotDefaultTabCharAndSizeForNoExtensionFile() {
-    when(mockFile.getFileExtension()).thenReturn(null);
-
-    FormattingOptions expectedFormattingOptions = getEclipseTextEditorFormattingOptions();
-    assertEquals(expectedFormattingOptions.isInsertSpaces(), formatOptionProvider.useSpace(mockFile));
-    assertEquals(expectedFormattingOptions.getTabSize(), formatOptionProvider.getTabSize(mockFile));
-  }
-
-  private FormattingOptions getEclipseTextEditorFormattingOptions() {
-    try {
-      IPreferencesService service = Platform.getPreferencesService();
-      boolean useSpaces = service.getBoolean(
-          EDITOR_PREF_NODE,
-          SPACES_FOR_TABS_KEY,
-          PREFERENCE_DEFAULT_USE_SPACE,
-          null
-      );
-      int tabSize = service.getInt(
-          EDITOR_PREF_NODE,
-          TAB_WIDTH_KEY,
-          PREFERENCE_DEFAULT_TAB_SIZE,
-          null
-      );
-      return new FormattingOptions(tabSize, useSpaces);
-    } catch (Exception e) {
-      return new FormattingOptions(PREFERENCE_DEFAULT_TAB_SIZE, PREFERENCE_DEFAULT_USE_SPACE);
-    }
+  private void setEditorFormattingPreferences(boolean useSpaces, int tabSize) {
+    IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(EDITOR_PREF_NODE);
+    prefs.putBoolean(SPACES_FOR_TABS_KEY, useSpaces);
+    prefs.putInt(TAB_WIDTH_KEY, tabSize);
   }
 }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
@@ -90,13 +90,13 @@ public class FormatOptionProvider {
     IProject project = file.getProject();
     if (project == null) {
       CopilotCore.LOGGER.info("Project is null for file: " + file.getName() + "default format will be applied.");
-      return null;
+      return getEclipseTextEditorFormattingOptions();
     }
 
     String fileExtension = file.getFileExtension();
     if (StringUtils.isEmpty(fileExtension)) {
       CopilotCore.LOGGER.info("File extension is null or empty for file: " + file.getName());
-      return null;
+      return getEclipseTextEditorFormattingOptions();
     } else {
       fileExtension = fileExtension.toLowerCase();
     }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
@@ -9,10 +9,9 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.lsp4j.FormattingOptions;
-import org.osgi.service.prefs.Preferences;
 
 import com.microsoft.copilot.eclipse.core.CopilotCore;
 
@@ -130,24 +129,21 @@ public class FormatOptionProvider {
    */
   private FormattingOptions getEclipseTextEditorFormattingOptions() {
     try {
-      Preferences instancePrefs = InstanceScope.INSTANCE.getNode(EDITOR_PREF_NODE);
-      Preferences defaultPrefs = DefaultScope.INSTANCE.getNode(EDITOR_PREF_NODE);
+      IPreferencesService service = Platform.getPreferencesService();
 
-      int tabSize;
-      String instanceTabWidth = instancePrefs.get(TAB_WIDTH_KEY, null);
-      if (instanceTabWidth != null) {
-        tabSize = instancePrefs.getInt(TAB_WIDTH_KEY, DEFAULT_TAB_SIZE);
-      } else {
-        tabSize = defaultPrefs.getInt(TAB_WIDTH_KEY, DEFAULT_TAB_SIZE);
-      }
+      boolean useSpaces = service.getBoolean(
+          EDITOR_PREF_NODE,
+          SPACES_FOR_TABS_KEY,
+          DEFAULT_USE_SPACE,
+          null
+      );
 
-      boolean useSpaces;
-      String instanceSpaces = instancePrefs.get(SPACES_FOR_TABS_KEY, null);
-      if (instanceSpaces != null) {
-        useSpaces = instancePrefs.getBoolean(SPACES_FOR_TABS_KEY, DEFAULT_USE_SPACE);
-      } else {
-        useSpaces = defaultPrefs.getBoolean(SPACES_FOR_TABS_KEY, DEFAULT_USE_SPACE);
-      }
+      int tabSize = service.getInt(
+          EDITOR_PREF_NODE,
+          TAB_WIDTH_KEY,
+          DEFAULT_TAB_SIZE,
+          null
+      );
 
       return new FormattingOptions(tabSize, useSpaces);
     } catch (Exception e) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
@@ -9,7 +9,10 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.lsp4j.FormattingOptions;
+import org.osgi.service.prefs.Preferences;
 
 import com.microsoft.copilot.eclipse.core.CopilotCore;
 
@@ -26,6 +29,9 @@ public class FormatOptionProvider {
   private static final String CPP_LANGUAGE_ID = "cpp";
   private static final String[] CPP_LANGUAGE_EXTENSIONS = new String[] { "cpp", "c++", "cc", "cp", "cxx", "h", "h++",
       "hh", ".hpp", ".hxx", ".inc", ".inl", ".ipp", ".tcc", ".tpp" };
+  private static final String EDITOR_PREF_NODE = "org.eclipse.ui.editors";
+  private static final String TAB_WIDTH_KEY = "tabWidth";
+  private static final String SPACES_FOR_TABS_KEY = "spacesForTabs";
   private static final boolean DEFAULT_USE_SPACE = LanguageFormatReader.PREFERENCE_DEFAULT_TAB_CHAR.equals("space");
   private static final int DEFAULT_TAB_SIZE = LanguageFormatReader.PREFERENCE_DEFAULT_TAB_SIZE;
 
@@ -110,13 +116,48 @@ public class FormatOptionProvider {
     if (languageFormatReaderForProject == null) {
       languageFormatReaderForProject = loadFormatReaderForTheProject(languageId, project);
       if (languageFormatReaderForProject == null) {
-        return new FormattingOptions(DEFAULT_TAB_SIZE, DEFAULT_USE_SPACE);
+        return getEclipseTextEditorFormattingOptions();
       }
       projectToLanguageFormatReaderMap.put(project, languageFormatReaderForProject);
     }
 
     return languageFormatReaderForProject.getFormattingOptions();
   }
+
+  /**
+   * Attempts to read the Eclipse default text editor preferences for tab size and spaces-for-tabs.
+   * Falls back to hardcoded defaults if the preferences cannot be read.
+   */
+  private FormattingOptions getEclipseTextEditorFormattingOptions() {
+    try {
+      Preferences instancePrefs = InstanceScope.INSTANCE.getNode(EDITOR_PREF_NODE);
+      Preferences defaultPrefs = DefaultScope.INSTANCE.getNode(EDITOR_PREF_NODE);
+
+      int tabSize;
+      String instanceTabWidth = instancePrefs.get(TAB_WIDTH_KEY, null);
+      if (instanceTabWidth != null) {
+        tabSize = instancePrefs.getInt(TAB_WIDTH_KEY, DEFAULT_TAB_SIZE);
+      } else {
+        tabSize = defaultPrefs.getInt(TAB_WIDTH_KEY, DEFAULT_TAB_SIZE);
+      }
+
+      boolean useSpaces;
+      String instanceSpaces = instancePrefs.get(SPACES_FOR_TABS_KEY, null);
+      if (instanceSpaces != null) {
+        useSpaces = instancePrefs.getBoolean(SPACES_FOR_TABS_KEY, DEFAULT_USE_SPACE);
+      } else {
+        useSpaces = defaultPrefs.getBoolean(SPACES_FOR_TABS_KEY, DEFAULT_USE_SPACE);
+      }
+
+      return new FormattingOptions(tabSize, useSpaces);
+    } catch (Exception e) {
+      CopilotCore.LOGGER.info(
+            "Failed to read Eclipse text editor preferences, using defaults");
+      return new FormattingOptions(DEFAULT_TAB_SIZE, DEFAULT_USE_SPACE);
+    }
+  }
+
+
 
   private LanguageFormatReader loadFormatReaderForTheProject(String languageId, IProject project) {
     switch (languageId) {


### PR DESCRIPTION
Read the default text editor preferences from Eclipse instead of defaulting to spaces by default. To avoid having additional plug-in dependencies, we use the existing preferences plug-in to check the multiple workspace instances for the settings. The 2 settings are the "spacesForTabs" and "tabWidth". If those settings are found, we will use those for the formatting options. If not, then it will continue to fall back to using defaults of using spaces. These settings are in effect when a project is neither a Java or C project type.