### PR TITLE
Fix prompt and skills discovery at workspace root level

### DIFF
--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/WorkspaceUtils.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/WorkspaceUtils.java
@@ -82,19 +82,42 @@ public class WorkspaceUtils {
   }
 
   /**
-   * List all top level projects as workspace folders in the current workspace.
+   * List all top level projects as workspace folders in the current workspace, including the workspace root.
    */
   public static List<WorkspaceFolder> listWorkspaceFolders() {
     List<IProject> projects = WorkspaceUtils.listTopLevelProjects();
 
     List<WorkspaceFolder> folders = new ArrayList<>();
+    java.util.Set<String> seenUris = new java.util.HashSet<>();
+
+    // Add workspace root first so it can be searched for root-level prompt files and skills
+    try {
+      URI workspaceRootUri = ResourcesPlugin.getWorkspace().getRoot().getLocationURI();
+      if (workspaceRootUri != null) {
+        String rootUriString = workspaceRootUri.toASCIIString();
+        WorkspaceFolder rootFolder = new WorkspaceFolder();
+        rootFolder.setUri(rootUriString);
+        rootFolder.setName("workspace-root");
+        folders.add(rootFolder);
+        seenUris.add(rootUriString);
+      }
+    } catch (Exception e) {
+      // If we can't get workspace root URI, continue with projects only
+    }
+
+    // Add top-level projects (avoiding duplicates)
     for (IProject project : projects) {
       URI uri = project.getLocationURI();
       if (uri != null) {
-        WorkspaceFolder folder = new WorkspaceFolder();
-        folder.setUri(uri.toASCIIString());
-        folder.setName(project.getName());
-        folders.add(folder);
+        String uriString = uri.toASCIIString();
+        // Avoid adding the same URI twice (project might be at workspace root in some configurations)
+        if (!seenUris.contains(uriString)) {
+          WorkspaceFolder folder = new WorkspaceFolder();
+          folder.setUri(uriString);
+          folder.setName(project.getName());
+          folders.add(folder);
+          seenUris.add(uriString);
+        }
       }
     }
     return folders;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
@@ -21,7 +21,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.service.event.EventHandler;
@@ -38,6 +37,7 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.ConversationTemplate;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotScope;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotStatusResult;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.TemplateSource;
+import com.microsoft.copilot.eclipse.core.utils.WorkspaceUtils;
 import com.microsoft.copilot.eclipse.ui.utils.PreferencesUtils;
 
 /**
@@ -115,7 +115,17 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
     // Pass workspace folders so the language server returns workspace-specific
     // prompt files (.prompt.md) and skills (SKILL.md) alongside built-in templates.
     try {
-      List<WorkspaceFolder> workspaceFolders = LSPEclipseUtils.getWorkspaceFolders();
+      List<WorkspaceFolder> workspaceFolders = WorkspaceUtils.listWorkspaceFolders();
+      // Log workspace folders for debugging prompt/skill discovery
+      if (!workspaceFolders.isEmpty()) {
+        StringBuilder folderLog = new StringBuilder("Discovering prompts and skills from workspace folders: ");
+        for (WorkspaceFolder folder : workspaceFolders) {
+          folderLog.append("[").append(folder.getName()).append(": ").append(folder.getUri()).append("] ");
+        }
+        CopilotCore.LOGGER.info(folderLog.toString());
+      } else {
+        CopilotCore.LOGGER.info("No workspace folders available for prompt and skill discovery");
+      }
       ConversationTemplate[] rawTemplates = this.lsConnection.listConversationTemplates(workspaceFolders).get();
       if (monitor.isCanceled()) {
         return;


### PR DESCRIPTION
Fixes #245 

This PR fixes the issue where prompts and skills files located at the workspace root directory (e.g., eclipse-workspace/.github) were not being discovered and loaded by the Copilot plugin with an SAP ADT projects.

## Root Cause
The WorkspaceUtils.listWorkspaceFolders() method only returned top-level Eclipse projects in the workspace, but never included the workspace root directory itself. This meant that:

- Prompt files (.prompt.md) and skill files (SKILL.md) placed at the workspace root level under .github/ were never discovered
- The language server had no way to search the workspace root for these files
- In SAP ADT environments, this was particularly problematic as projects are not structured as standard Eclipse projects

## Solution
Modified WorkspaceUtils.listWorkspaceFolders() to:

- Include workspace root as the first workspace folder in the list
- Add deduplication logic to prevent duplicate URIs when a project is located at the workspace root
- Gracefully handle errors when accessing the workspace root URI

## Changes Made:
`com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/WorkspaceUtils.java`

- Modified listWorkspaceFolders() to include workspace root URI with name "workspace-root"
- Added a Set<String> for tracking seen URIs to prevent duplicates
- Added error handling for edge cases when retrieving workspace root

`com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java`

- Added debug logging to show which workspace folders are being used for prompt and skill discovery
- Logs the name and URI of each workspace folder being searched