### PR TITLE
fix: hide scrollbar in dropdown popup on Linux GTK

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/DropdownPopup.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/DropdownPopup.java
@@ -135,6 +135,7 @@ class DropdownPopup {
     scrolledComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     scrolledComposite.setExpandHorizontal(true);
     scrolledComposite.setExpandVertical(true);
+    scrolledComposite.setAlwaysShowScrollBars(false);
     scrolledComposite.setData(CssConstants.CSS_ID_KEY, "dropdown-popup");
     scrolledComposite.setBackground(popupBg);
     styleControl(scrolledComposite);


### PR DESCRIPTION
Fixes microsoft/copilot-for-eclipse#113

## Problem

On Linux GTK, the ScrolledComposite in DropdownPopup always renders a scrollbar
even when all content fits within the visible area. This causes detailed model
information displayed on hover tooltips to be cropped, as the scrollbar overlay
interferes with the rendering of hover content.

## Fix

Added  after creating the
ScrolledComposite in the constructor. This matches the pattern already used in
 (line 258) and  (line 119) in the same codebase.

## Testing

- Verified the fix aligns with existing patterns in the codebase
- No functional change on Windows/macOS where scrollbars are hidden by default