### PR TITLE
fix: clear closed editor file context

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileServiceTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileServiceTest.java
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.copilot.eclipse.ui.chat.services;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IPartService;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.copilot.eclipse.ui.utils.UiUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ReferencedFileServiceTest {
+
+  @Mock
+  private IWorkbench workbench;
+
+  @Mock
+  private IWorkbenchWindow window;
+
+  @Mock
+  private IPartService partService;
+
+  @Mock
+  private IWorkbenchPage activePage;
+
+  @Mock
+  private IEditorReference remainingEditorReference;
+
+  @Mock
+  private IWorkbenchPartReference closedPartReference;
+
+  @Mock
+  private IEditorPart closedEditor;
+
+  @Mock
+  private IFile currentFile;
+
+  @Test
+  void partClosed_WhenClosedEditorIsCurrentFileAndEditorReferencesRemain_ShouldClearCurrentFile()
+      throws Exception {
+    try (MockedStatic<PlatformUI> platformUi = mockStatic(PlatformUI.class);
+        MockedStatic<UiUtils> uiUtils = mockStatic(UiUtils.class)) {
+      platformUi.when(PlatformUI::getWorkbench).thenReturn(workbench);
+      when(workbench.getWorkbenchWindows()).thenReturn(new IWorkbenchWindow[] { window });
+      when(window.getPartService()).thenReturn(partService);
+
+      ReferencedFileService service = new ReferencedFileService();
+      try {
+        IPartListener2 listener = getRegisteredPartListener();
+        when(closedPartReference.getPart(false)).thenReturn(closedEditor);
+        uiUtils.when(() -> UiUtils.getFileFromEditorPart(closedEditor)).thenReturn(currentFile);
+        uiUtils.when(UiUtils::getActivePage).thenReturn(activePage);
+        when(activePage.getEditorReferences()).thenReturn(new IEditorReference[] { remainingEditorReference });
+
+        setCurrentFile(service, currentFile);
+        assertSame(currentFile, service.getCurrentFile());
+
+        listener.partClosed(closedPartReference);
+
+        assertNull(service.getCurrentFile());
+      } finally {
+        service.dispose();
+      }
+    }
+  }
+
+  private IPartListener2 getRegisteredPartListener() {
+    ArgumentCaptor<IPartListener2> listenerCaptor = ArgumentCaptor.forClass(IPartListener2.class);
+    verify(partService).addPartListener(listenerCaptor.capture());
+    return listenerCaptor.getValue();
+  }
+
+  private static void setCurrentFile(ReferencedFileService service, IFile file) throws Exception {
+    Object currentFileObservable = getField(service, "currentFileObservable");
+    runOnDisplayThread(() -> invokeSetValue(currentFileObservable, file));
+  }
+
+  private static Object getField(Object target, String fieldName) throws NoSuchFieldException,
+      IllegalAccessException {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static void runOnDisplayThread(Runnable runnable) {
+    if (Display.getCurrent() != null) {
+      runnable.run();
+      return;
+    }
+    Display.getDefault().syncExec(runnable);
+  }
+
+  private static void invokeSetValue(Object observable, Object value) {
+    try {
+      Method setValue = observable.getClass().getMethod("setValue", Object.class);
+      setValue.invoke(observable, value);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("Failed to set observable value", e);
+    }
+  }
+}

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileServiceTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileServiceTest.java
@@ -9,19 +9,15 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import org.eclipse.core.resources.IFile;
-import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IPartService;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.junit.jupiter.api.Test;
@@ -49,13 +45,22 @@ class ReferencedFileServiceTest {
   private IWorkbenchPage activePage;
 
   @Mock
+  private IWorkbenchPage otherPage;
+
+  @Mock
+  private IEditorReference closedEditorReference;
+
+  @Mock
   private IEditorReference remainingEditorReference;
 
   @Mock
-  private IWorkbenchPartReference closedPartReference;
+  private IEditorPart closedEditor;
 
   @Mock
-  private IEditorPart closedEditor;
+  private IFileEditorInput closedEditorInput;
+
+  @Mock
+  private IEditorInput nonFileEditorInput;
 
   @Mock
   private IFile currentFile;
@@ -69,20 +74,80 @@ class ReferencedFileServiceTest {
       when(workbench.getWorkbenchWindows()).thenReturn(new IWorkbenchWindow[] { window });
       when(window.getPartService()).thenReturn(partService);
 
-      ReferencedFileService service = new ReferencedFileService();
+      TestReferencedFileService service = new TestReferencedFileService();
       try {
         IPartListener2 listener = getRegisteredPartListener();
-        when(closedPartReference.getPart(false)).thenReturn(closedEditor);
+        when(closedEditorReference.getEditorInput()).thenReturn(nonFileEditorInput);
+        when(closedEditorReference.getPart(false)).thenReturn(closedEditor);
         uiUtils.when(() -> UiUtils.getFileFromEditorPart(closedEditor)).thenReturn(currentFile);
-        uiUtils.when(UiUtils::getActivePage).thenReturn(activePage);
+        when(window.getPages()).thenReturn(new IWorkbenchPage[] { activePage });
         when(activePage.getEditorReferences()).thenReturn(new IEditorReference[] { remainingEditorReference });
 
-        setCurrentFile(service, currentFile);
+        service.setCurrentFile(currentFile);
         assertSame(currentFile, service.getCurrentFile());
 
-        listener.partClosed(closedPartReference);
+        listener.partClosed(closedEditorReference);
 
         assertNull(service.getCurrentFile());
+      } finally {
+        service.dispose();
+      }
+    }
+  }
+
+  @Test
+  void partClosed_WhenEditorPartIsDisposedButReferenceInputIsCurrentFile_ShouldClearCurrentFile()
+      throws Exception {
+    try (MockedStatic<PlatformUI> platformUi = mockStatic(PlatformUI.class)) {
+      platformUi.when(PlatformUI::getWorkbench).thenReturn(workbench);
+      when(workbench.getWorkbenchWindows()).thenReturn(new IWorkbenchWindow[] { window });
+      when(window.getPartService()).thenReturn(partService);
+
+      TestReferencedFileService service = new TestReferencedFileService();
+      try {
+        IPartListener2 listener = getRegisteredPartListener();
+        when(closedEditorReference.getEditorInput()).thenReturn(closedEditorInput);
+        when(closedEditorInput.getFile()).thenReturn(currentFile);
+        when(window.getPages()).thenReturn(new IWorkbenchPage[] { activePage });
+        when(activePage.getEditorReferences()).thenReturn(new IEditorReference[] { remainingEditorReference });
+
+        service.setCurrentFile(currentFile);
+        assertSame(currentFile, service.getCurrentFile());
+
+        listener.partClosed(closedEditorReference);
+
+        assertNull(service.getCurrentFile());
+      } finally {
+        service.dispose();
+      }
+    }
+  }
+
+  @Test
+  void partClosed_WhenActivePageHasNoEditorsButAnotherPageHasEditors_ShouldKeepCurrentFile()
+      throws Exception {
+    try (MockedStatic<PlatformUI> platformUi = mockStatic(PlatformUI.class);
+        MockedStatic<UiUtils> uiUtils = mockStatic(UiUtils.class)) {
+      platformUi.when(PlatformUI::getWorkbench).thenReturn(workbench);
+      when(workbench.getWorkbenchWindows()).thenReturn(new IWorkbenchWindow[] { window });
+      when(window.getPartService()).thenReturn(partService);
+
+      TestReferencedFileService service = new TestReferencedFileService();
+      try {
+        IPartListener2 listener = getRegisteredPartListener();
+        when(closedEditorReference.getEditorInput()).thenReturn(nonFileEditorInput);
+        when(closedEditorReference.getPart(false)).thenReturn(closedEditor);
+        uiUtils.when(() -> UiUtils.getFileFromEditorPart(closedEditor)).thenReturn(null);
+        when(window.getPages()).thenReturn(new IWorkbenchPage[] { activePage, otherPage });
+        when(activePage.getEditorReferences()).thenReturn(new IEditorReference[0]);
+        when(otherPage.getEditorReferences()).thenReturn(new IEditorReference[] { remainingEditorReference });
+
+        service.setCurrentFile(currentFile);
+        assertSame(currentFile, service.getCurrentFile());
+
+        listener.partClosed(closedEditorReference);
+
+        assertSame(currentFile, service.getCurrentFile());
       } finally {
         service.dispose();
       }
@@ -95,32 +160,9 @@ class ReferencedFileServiceTest {
     return listenerCaptor.getValue();
   }
 
-  private static void setCurrentFile(ReferencedFileService service, IFile file) throws Exception {
-    Object currentFileObservable = getField(service, "currentFileObservable");
-    runOnDisplayThread(() -> invokeSetValue(currentFileObservable, file));
-  }
-
-  private static Object getField(Object target, String fieldName) throws NoSuchFieldException,
-      IllegalAccessException {
-    Field field = target.getClass().getDeclaredField(fieldName);
-    field.setAccessible(true);
-    return field.get(target);
-  }
-
-  private static void runOnDisplayThread(Runnable runnable) {
-    if (Display.getCurrent() != null) {
-      runnable.run();
-      return;
-    }
-    Display.getDefault().syncExec(runnable);
-  }
-
-  private static void invokeSetValue(Object observable, Object value) {
-    try {
-      Method setValue = observable.getClass().getMethod("setValue", Object.class);
-      setValue.invoke(observable, value);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("Failed to set observable value", e);
+  private static class TestReferencedFileService extends ReferencedFileService {
+    void setCurrentFile(IFile file) {
+      setCurrentFileForTest(file);
     }
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
@@ -26,13 +26,19 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.ResourceUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.microsoft.copilot.eclipse.core.Constants;
@@ -478,12 +484,7 @@ public class ReferencedFileService extends ChatBaseService implements IReference
   }
 
   private boolean isCurrentReferencedFile(IWorkbenchPartReference partRef) {
-    IWorkbenchPart part = partRef.getPart(false);
-    if (!(part instanceof IEditorPart editorPart)) {
-      return false;
-    }
-
-    IFile closedFile = UiUtils.getFileFromEditorPart(editorPart);
+    IFile closedFile = getFileFromPartReference(partRef);
     if (closedFile == null) {
       return false;
     }
@@ -493,9 +494,71 @@ public class ReferencedFileService extends ChatBaseService implements IReference
     return closedFile.equals(currentFile.get());
   }
 
+  private IFile getFileFromPartReference(IWorkbenchPartReference partRef) {
+    if (partRef instanceof IEditorReference editorReference) {
+      IFile file = getFileFromEditorReference(editorReference);
+      if (file != null) {
+        return file;
+      }
+    }
+
+    IWorkbenchPart part = partRef.getPart(false);
+    if (part instanceof IEditorPart editorPart) {
+      return UiUtils.getFileFromEditorPart(editorPart);
+    }
+    return null;
+  }
+
+  private IFile getFileFromEditorReference(IEditorReference editorReference) {
+    try {
+      return getFileFromEditorInput(editorReference.getEditorInput());
+    } catch (PartInitException e) {
+      CopilotCore.LOGGER.error("Failed to get editor input from part reference", e);
+      return null;
+    }
+  }
+
+  private IFile getFileFromEditorInput(IEditorInput input) {
+    if (input instanceof IFileEditorInput fileEditorInput) {
+      return fileEditorInput.getFile();
+    }
+    return ResourceUtil.getFile(input);
+  }
+
   private boolean hasNoOpenEditors() {
-    IWorkbenchPage page = UiUtils.getActivePage();
-    return page == null || page.getEditorReferences().length == 0;
+    IWorkbench workbench = PlatformUI.getWorkbench();
+    if (workbench == null) {
+      return true;
+    }
+
+    IWorkbenchWindow[] windows = workbench.getWorkbenchWindows();
+    if (windows == null || windows.length == 0) {
+      return true;
+    }
+
+    for (IWorkbenchWindow window : windows) {
+      if (window == null) {
+        continue;
+      }
+
+      IWorkbenchPage[] pages = window.getPages();
+      if (pages == null || pages.length == 0) {
+        IWorkbenchPage activePage = window.getActivePage();
+        pages = activePage == null ? new IWorkbenchPage[0] : new IWorkbenchPage[] { activePage };
+      }
+
+      for (IWorkbenchPage page : pages) {
+        if (page == null) {
+          continue;
+        }
+
+        IEditorReference[] editorReferences = page.getEditorReferences();
+        if (editorReferences != null && editorReferences.length > 0) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private void clearCurrentReferencedFile() {
@@ -503,6 +566,13 @@ public class ReferencedFileService extends ChatBaseService implements IReference
       currentFileObservable.setValue(null);
       currentSelectionObservable.setValue(null);
     });
+  }
+
+  /**
+   * Sets the current file for tests.
+   */
+  protected void setCurrentFileForTest(IFile file) {
+    ensureRealm(() -> currentFileObservable.setValue(file));
   }
 
   private void updateCurrentReferencedFile(IEditorPart editorPart) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
@@ -105,12 +105,10 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
       @Override
       public void partClosed(IWorkbenchPartReference partRef) {
-        IWorkbenchPage page = UiUtils.getActivePage();
-        if (page == null || page.getEditorReferences().length == 0) {
-          ensureRealm(() -> {
-            currentFileObservable.setValue(null);
-            currentSelectionObservable.setValue(null);
-          });
+        boolean closedCurrentFile = isCurrentReferencedFile(partRef);
+        boolean noOpenEditors = hasNoOpenEditors();
+        if (closedCurrentFile || noOpenEditors) {
+          clearCurrentReferencedFile();
         }
         untrackSelectionInEditor(partRef);
       }
@@ -477,6 +475,34 @@ public class ReferencedFileService extends ChatBaseService implements IReference
     if (part instanceof IEditorPart editorPart) {
       updateCurrentReferencedFile(editorPart);
     }
+  }
+
+  private boolean isCurrentReferencedFile(IWorkbenchPartReference partRef) {
+    IWorkbenchPart part = partRef.getPart(false);
+    if (!(part instanceof IEditorPart editorPart)) {
+      return false;
+    }
+
+    IFile closedFile = UiUtils.getFileFromEditorPart(editorPart);
+    if (closedFile == null) {
+      return false;
+    }
+
+    AtomicReference<IFile> currentFile = new AtomicReference<>();
+    ensureRealm(() -> currentFile.set(currentFileObservable.getValue()));
+    return closedFile.equals(currentFile.get());
+  }
+
+  private boolean hasNoOpenEditors() {
+    IWorkbenchPage page = UiUtils.getActivePage();
+    return page == null || page.getEditorReferences().length == 0;
+  }
+
+  private void clearCurrentReferencedFile() {
+    ensureRealm(() -> {
+      currentFileObservable.setValue(null);
+      currentSelectionObservable.setValue(null);
+    });
   }
 
   private void updateCurrentReferencedFile(IEditorPart editorPart) {


### PR DESCRIPTION
## Summary

Fixes #277.

When an editor closes, `ReferencedFileService` now checks whether the closed editor is the file currently represented in Copilot Chat. If it is, the service clears both the current-file observable and current-selection observable immediately. This keeps the existing fallback behavior for the final-editor-close case, but no longer depends only on the workbench editor reference count, which can still include an editor while focus has moved to a non-editor view.

The regression test captures the part listener registered by `ReferencedFileService`, seeds the current file observable, simulates closing that same editor while another editor reference is still reported by the active page, and asserts the chat current file is cleared.

## Testing

- `git diff --check`
- `./mvnw -pl com.microsoft.copilot.eclipse.terminal.api,com.microsoft.copilot.eclipse.core,com.microsoft.copilot.eclipse.ui,com.microsoft.copilot.eclipse.ui.test -am -Dtest=ReferencedFileServiceTest test`

I also tried the same module set with `verify`, but it stops in packaging because `com.microsoft.copilot.eclipse.core/build.properties` expects `copilot-agent/dist/`, which is not present in this checkout.
