### PR TITLE
feat: make skills generally available

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/SkillsPreferencesUtilsTest.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/utils/SkillsPreferencesUtilsTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.copilot.eclipse.ui.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.microsoft.copilot.eclipse.core.Constants;
+import com.microsoft.copilot.eclipse.core.CopilotCore;
+import com.microsoft.copilot.eclipse.core.FeatureFlags;
+import com.microsoft.copilot.eclipse.ui.CopilotUi;
+
+class SkillsPreferencesUtilsTest {
+
+  @Test
+  void testIsSkillsEnabled_previewDisabledAndPreferenceEnabled_returnsTrue() {
+    IPreferenceStore preferenceStore = mock(IPreferenceStore.class);
+    CopilotUi uiPlugin = mock(CopilotUi.class);
+    // Keep preview disabled to prevent it from becoming a Skills prerequisite again.
+    CopilotCore corePlugin = mock(CopilotCore.class);
+    FeatureFlags featureFlags = mock(FeatureFlags.class);
+    when(uiPlugin.getPreferenceStore()).thenReturn(preferenceStore);
+    when(preferenceStore.getBoolean(Constants.ENABLE_SKILLS)).thenReturn(true);
+    when(corePlugin.getFeatureFlags()).thenReturn(featureFlags);
+    when(featureFlags.isClientPreviewFeatureEnabled()).thenReturn(false);
+
+    try (MockedStatic<CopilotUi> copilotUi = Mockito.mockStatic(CopilotUi.class);
+        MockedStatic<CopilotCore> copilotCore = Mockito.mockStatic(CopilotCore.class)) {
+      copilotUi.when(CopilotUi::getPlugin).thenReturn(uiPlugin);
+      copilotCore.when(CopilotCore::getPlugin).thenReturn(corePlugin);
+
+      assertTrue(PreferencesUtils.isSkillsEnabled());
+    }
+  }
+
+  @Test
+  void testIsSkillsEnabled_preferenceDisabled_returnsFalse() {
+    IPreferenceStore preferenceStore = mock(IPreferenceStore.class);
+    CopilotUi uiPlugin = mock(CopilotUi.class);
+    when(uiPlugin.getPreferenceStore()).thenReturn(preferenceStore);
+    when(preferenceStore.getBoolean(Constants.ENABLE_SKILLS)).thenReturn(false);
+
+    try (MockedStatic<CopilotUi> copilotUi = Mockito.mockStatic(CopilotUi.class)) {
+      copilotUi.when(CopilotUi::getPlugin).thenReturn(uiPlugin);
+
+      assertFalse(PreferencesUtils.isSkillsEnabled());
+    }
+  }
+}

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ChatPreferencesPage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ChatPreferencesPage.java
@@ -21,7 +21,6 @@ import org.osgi.service.prefs.BackingStoreException;
 
 import com.microsoft.copilot.eclipse.core.Constants;
 import com.microsoft.copilot.eclipse.core.CopilotCore;
-import com.microsoft.copilot.eclipse.core.FeatureFlags;
 import com.microsoft.copilot.eclipse.ui.CopilotUi;
 
 /**
@@ -54,18 +53,14 @@ public class ChatPreferencesPage extends FieldEditorPreferencePage implements IW
     addNote(parent, Messages.preferences_page_watched_files_note_content);
     addSeparator(parent);
 
-    if (isClientPreviewFeatureEnabled()) {
-      // Add Enable Skills toggle
-      Composite skillsComposite = createSectionComposite(parent, gdf);
+    Composite skillsComposite = createSectionComposite(parent, gdf);
+    BooleanFieldEditor skillsField = new BooleanFieldEditor(Constants.ENABLE_SKILLS,
+        Messages.preferences_page_skills_enabled, SWT.WRAP, skillsComposite);
+    applyFieldWidthHint(skillsField, skillsComposite);
+    addField(skillsField);
 
-      BooleanFieldEditor skillsField = new BooleanFieldEditor(Constants.ENABLE_SKILLS,
-          Messages.preferences_page_skills_enabled, SWT.WRAP, skillsComposite);
-      applyFieldWidthHint(skillsField, skillsComposite);
-      addField(skillsField);
-
-      addNote(parent, Messages.preferences_page_skills_enabled_note_content);
-      addSeparator(parent);
-    }
+    addNote(parent, Messages.preferences_page_skills_enabled_note_content);
+    addSeparator(parent);
 
     // Add Agent Max Requests field
     Composite agentMaxRequestsComposite = createSectionComposite(parent, gdf);
@@ -137,10 +132,5 @@ public class ChatPreferencesPage extends FieldEditorPreferencePage implements IW
     GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
     gridData.horizontalSpan = 2;
     separator.setLayoutData(gridData);
-  }
-
-  private boolean isClientPreviewFeatureEnabled() {
-    FeatureFlags flags = CopilotCore.getPlugin().getFeatureFlags();
-    return flags != null && flags.isClientPreviewFeatureEnabled();
   }
 }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/PreferencesUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/PreferencesUtils.java
@@ -9,7 +9,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.microsoft.copilot.eclipse.core.Constants;
 import com.microsoft.copilot.eclipse.core.CopilotCore;
-import com.microsoft.copilot.eclipse.core.FeatureFlags;
 import com.microsoft.copilot.eclipse.core.chat.CustomInstructionsChatLoadScope;
 import com.microsoft.copilot.eclipse.ui.CopilotUi;
 import com.microsoft.copilot.eclipse.ui.preferences.AutoApprovePreferencePage;
@@ -38,16 +37,12 @@ public class PreferencesUtils {
   }
 
   /**
-   * Returns whether the skills feature is enabled. Skills require both the user preference
-   * {@link Constants#ENABLE_SKILLS} to be set and the client preview feature flag to be enabled.
+   * Returns whether the skills feature is enabled.
    *
    * @return {@code true} if skills are enabled, {@code false} otherwise
    */
   public static boolean isSkillsEnabled() {
-    CopilotCore plugin = CopilotCore.getPlugin();
-    FeatureFlags flags = plugin != null ? plugin.getFeatureFlags() : null;
-    return CopilotUi.getPlugin().getPreferenceStore().getBoolean(Constants.ENABLE_SKILLS)
-        && flags != null && flags.isClientPreviewFeatureEnabled();
+    return CopilotUi.getPlugin().getPreferenceStore().getBoolean(Constants.ENABLE_SKILLS);
   }
 
   /**


### PR DESCRIPTION
Remove the editor preview feature flag dependency from Skills while retaining the Enable Skills preference.

fix #302 