### PR TITLE
fix: prevent terminal hangs when PowerShell prompt fails

### DIFF
--- a/com.microsoft.copilot.eclipse.terminal.api/scripts/copilot-powershell-integration.ps1
+++ b/com.microsoft.copilot.eclipse.terminal.api/scripts/copilot-powershell-integration.ps1
@@ -39,12 +39,19 @@ if (-not $global:COPILOT_SHELL_INTEGRATION) {
 
         $result += "$esc]7775;A$bel"
 
+        $promptText = $null
         if ($global:__copilot_original_prompt) {
-            $result += $global:__copilot_original_prompt.Invoke()
-        } else {
-            $result += "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+            try {
+                $promptText = & $global:__copilot_original_prompt 2>$null
+            } catch {
+                $promptText = $null
+            }
         }
 
+        if ($null -eq $promptText -or "$promptText" -eq "") {
+            $promptText = "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+        }
+        $result += $promptText
         $result += "$esc]7775;B$bel"
         if ($null -ne $lastHistoryEntry) {
             $global:__copilot_last_history_id = $lastHistoryEntry.Id


### PR DESCRIPTION
## Summary

Fixes Agent mode hanging indefinitely after a terminal command completes on Windows.

## Root cause

The PowerShell integration invoked the original prompt using `ScriptBlock.Invoke()`. This method call is blocked in `ConstrainedLanguage` mode. A user-defined prompt could also throw an exception or return no output.

When the prompt failed, the shell integration did not emit its prompt-end marker. Consequently, the terminal command future never completed and Agent mode remained stuck on `Running run_in_terminal tool`.

## Changes

- Execute the original prompt using PowerShell's call operator instead of `.Invoke()`.
- Catch failures from user-defined prompt functions.
- Fall back to a standard prompt containing the current directory when the original prompt fails or returns no output.
- Ensure shell completion markers continue to be emitted.

## Validation

- Reproduced the hang in `ConstrainedLanguage` mode.
- Verified terminal commands complete after the fix in `ConstrainedLanguage` mode.
- Verified fallback behavior when a custom prompt:
  - throws an exception;
  - returns `$null`.
- Verified normal PowerShell prompt behavior remains unchanged.
- `.\mvnw checkstyle:check` passed.
- `.\mvnw test` passed.

Fixes #375