### PR TITLE
Activate checkstyle rules for missing @param and @return entries in javadoc comments; fix missing entries in comments

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -396,8 +396,8 @@
     </module>
     <module name="JavadocMethod">
       <property name="accessModifiers" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingParamTags" value="false"/>
+      <property name="allowMissingReturnTag" value="false"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
     </module>

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/AuthStatusManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/AuthStatusManager.java
@@ -52,6 +52,7 @@ public class AuthStatusManager {
   /**
    * Initiate the sign in process.
    *
+   * @return the sign-in initiation result from the language server.
    * @throws ExecutionException if the sign in initiate process fails due to an execution error
    * @throws InterruptedException if the sign in initiate process is interrupted
    */
@@ -67,6 +68,8 @@ public class AuthStatusManager {
   /**
    * Confirm the sign in process.
    *
+   * @param userCode the user code returned by the sign-in initiation.
+   * @return the updated Copilot status result after sign-in confirmation.
    * @throws ExecutionException if the sign in process fails due to an execution error
    * @throws InterruptedException if the sign in process is interrupted
    */
@@ -85,6 +88,7 @@ public class AuthStatusManager {
   /**
    * Sign out from the GitHub Copilot.
    *
+   * @return the updated Copilot status result after signing out.
    * @throws ExecutionException if the sign out process fails due to an execution error
    * @throws InterruptedException if the sign out process is interrupted
    */
@@ -97,6 +101,9 @@ public class AuthStatusManager {
 
   /**
    * Set the CopilotStatusResult string to the given status and notify the listeners.
+   *
+   * @param newCopilotStatusResult the new Copilot status value.
+   * @return the updated Copilot status result.
    */
   public CopilotStatusResult setCopilotStatus(String newCopilotStatusResult) {
     if (!Objects.equals(this.copilotStatusResult.getStatus(), newCopilotStatusResult)) {
@@ -142,6 +149,8 @@ public class AuthStatusManager {
 
   /**
    * Set the user for Copilot.
+   *
+   * @param user the Copilot user name to set.
    */
   public void setCopilotUser(String user) {
     this.copilotStatusResult.setUser(user);
@@ -149,6 +158,8 @@ public class AuthStatusManager {
 
   /**
    * Get the current status of the copilot.
+   *
+   * @return the current Copilot status.
    */
   public String getCopilotStatus() {
     if (this.copilotStatusResult == null) {
@@ -159,6 +170,8 @@ public class AuthStatusManager {
 
   /**
    * Get the name of the login user.
+   *
+   * @return the name of the signed-in user, or an empty string if no user is available.
    */
   public String getUserName() {
     if (this.copilotStatusResult == null) {
@@ -172,6 +185,8 @@ public class AuthStatusManager {
 
   /**
    * Set the CheckQuotaResult.
+   *
+   * @param checkQuotaResult the quota status result to set.
    */
   public void setQuotaStatus(CheckQuotaResult checkQuotaResult) {
     this.checkQuotaResult = checkQuotaResult;
@@ -179,6 +194,8 @@ public class AuthStatusManager {
 
   /**
    * Get the current CopilotStatusResult.
+   *
+   * @return the current quota status result.
    */
   public CheckQuotaResult getQuotaStatus() {
     if (this.checkQuotaResult == null) {
@@ -189,6 +206,8 @@ public class AuthStatusManager {
 
   /**
    * Add a listener for the authentication status.
+   *
+   * @param listener the listener to add.
    */
   public void addCopilotAuthStatusListener(CopilotAuthStatusListener listener) {
     this.copilotAuthStatusListeners.add(listener);
@@ -196,6 +215,8 @@ public class AuthStatusManager {
 
   /**
    * Remove the listener for the authentication status.
+   *
+   * @param listener the listener to remove.
    */
   public void removeCopilotAuthStatusListener(CopilotAuthStatusListener listener) {
     this.copilotAuthStatusListeners.remove(listener);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/CopilotAuthStatusListener.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/CopilotAuthStatusListener.java
@@ -12,6 +12,8 @@ public interface CopilotAuthStatusListener {
 
   /**
    * Notifies to the listeners when the authentication status is changed.
+   *
+   * @param copilotStatusResult the updated Copilot status result.
    */
   void onDidCopilotStatusChange(CopilotStatusResult copilotStatusResult);
 }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/CopilotCore.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/CopilotCore.java
@@ -149,6 +149,8 @@ public class CopilotCore extends Plugin {
 
   /**
    * Get the next edit suggestion provider in lazy-load manner.
+   *
+   * @return the next edit suggestion provider.
    */
   public NextEditSuggestionProvider getNextEditSuggestionProvider() {
     if (this.nextEditSuggestionProvider == null) {
@@ -163,6 +165,8 @@ public class CopilotCore extends Plugin {
 
   /**
    * Get the format option provider in lazy-load manner.
+   *
+   * @return the format option provider.
    */
   public FormatOptionProvider getFormatOptionProvider() {
     if (this.formatOptionProvider == null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ChatEventsManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ChatEventsManager.java
@@ -36,6 +36,8 @@ public class ChatEventsManager {
 
   /**
    * Add a listener to the chat progress provider.
+   *
+   * @param listener the listener to add.
    */
   public void addChatProgressListener(ChatProgressListener listener) {
     this.chatProgressListeners.add(listener);
@@ -43,6 +45,8 @@ public class ChatEventsManager {
 
   /**
    * Remove a listener from the chat progress provider.
+   *
+   * @param listener the listener to remove.
    */
   public void removeChatProgressListener(ChatProgressListener listener) {
     this.chatProgressListeners.remove(listener);
@@ -50,6 +54,8 @@ public class ChatEventsManager {
 
   /**
    * Notify the progress to the listeners.
+   *
+   * @param message the progress message to notify.
    */
   public void notifyProgress(ChatProgressValue message) {
     for (ChatProgressListener listener : this.chatProgressListeners) {
@@ -79,6 +85,7 @@ public class ChatEventsManager {
    * Notify the listeners when the agent tool should be confirmed.
    *
    * @param params the parameters for the tool confirmation
+   * @return a future containing the tool confirmation result.
    */
   public CompletableFuture<LanguageModelToolConfirmationResult> confirmAgentToolInvocation(
       InvokeClientToolConfirmationParams params) {
@@ -93,6 +100,7 @@ public class ChatEventsManager {
    * Notify the listeners when the agent tool should be invoked.
    *
    * @param params the parameters for the tool invocation
+   * @return a future containing the tool invocation results.
    */
   public CompletableFuture<LanguageModelToolResult[]> invokeAgentTool(InvokeClientToolParams params) {
     if (this.agentToolListener == null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ChatProgressListener.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ChatProgressListener.java
@@ -11,6 +11,8 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.ChatProgressValue;
 public interface ChatProgressListener {
   /**
    * Notifies to the listeners when the chat is resolved.
+   *
+   * @param progress the chat progress value.
    */
   public void onChatProgress(ChatProgressValue progress);
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ConfirmationAction.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ConfirmationAction.java
@@ -63,13 +63,23 @@ public class ConfirmationAction {
     return primary;
   }
 
-  /** Creates a primary accept action (scope = ONCE). */
+  /**
+   * Creates a primary accept action (scope = ONCE).
+   *
+   * @param label the button label.
+   * @return the primary accept confirmation action.
+   */
   public static ConfirmationAction allowOnce(String label) {
     return new ConfirmationAction(label, true,
         ConfirmationActionScope.ONCE, null, true);
   }
 
-  /** Creates a dismiss action. */
+  /**
+   * Creates a dismiss action.
+   *
+   * @param label the button label.
+   * @return the dismiss confirmation action.
+   */
   public static ConfirmationAction skip(String label) {
     return new ConfirmationAction(label, false, null, null, false);
   }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ConfirmationResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/ConfirmationResult.java
@@ -29,7 +29,12 @@ public class ConfirmationResult {
     this.content = content;
   }
 
-  /** Creates a result that requires user confirmation with the given content. */
+  /**
+   * Creates a result that requires user confirmation with the given content.
+   *
+   * @param content the confirmation content to show.
+   * @return the confirmation result requiring user confirmation.
+   */
   public static ConfirmationResult needsConfirmation(
       ConfirmationContent content) {
     return new ConfirmationResult(false, false, content);
@@ -39,12 +44,20 @@ public class ConfirmationResult {
     return autoApproved;
   }
 
-  /** Returns true if the request should be dismissed without showing UI. */
+  /**
+   * Returns true if the request should be dismissed without showing UI.
+   *
+   * @return true if the request should be dismissed without showing UI.
+   */
   public boolean isDismissed() {
     return dismissed;
   }
 
-  /** Returns the confirmation content, or null if auto-approved or using defaults. */
+  /**
+   * Returns the confirmation content, or null if auto-approved or using defaults.
+   *
+   * @return the confirmation content, or null if auto-approved or using defaults.
+   */
   public ConfirmationContent getContent() {
     return content;
   }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/InputNavigation.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/InputNavigation.java
@@ -51,6 +51,8 @@ public class InputNavigation {
 
   /**
    * Add a new input to the history and update the cursor.
+   *
+   * @param input the input text to add.
    */
   public void add(String input) {
     if (StringUtils.isBlank(input) || Objects.equals(input, getLatestInput())) {
@@ -66,6 +68,8 @@ public class InputNavigation {
 
   /**
    * Navigate to the last input in the history.
+   *
+   * @return the previous input in the history, or an empty string if unavailable.
    */
   public String navigateUp() {
     if (inputHistory.isEmpty() || atTop()) {
@@ -79,6 +83,8 @@ public class InputNavigation {
 
   /**
    * Navigate to the next input in the history.
+   *
+   * @return the next input in the history, or an empty string if unavailable.
    */
   public String navigateDown() {
     if (inputHistory.isEmpty() || atBottom()) {
@@ -92,6 +98,8 @@ public class InputNavigation {
 
   /**
    * Check if the current position is at the bottom(latest) of the history.
+   *
+   * @return true if the current position is at the bottom of the history.
    */
   public boolean atBottom() {
     return inputHistory.isEmpty() || currentPosition == inputHistory.size();
@@ -99,6 +107,8 @@ public class InputNavigation {
 
   /**
    * Check if the current position is at the top(oldest) of the history.
+   *
+   * @return true if the current position is at the top of the history.
    */
   public boolean atTop() {
     return inputHistory.isEmpty() || currentPosition == 0;
@@ -106,6 +116,8 @@ public class InputNavigation {
 
   /**
    * Get the latest input from the history.
+   *
+   * @return the latest input, or an empty string if the history is empty.
    */
   public String getLatestInput() {
     if (inputHistory.isEmpty()) {
@@ -116,6 +128,8 @@ public class InputNavigation {
 
   /**
    * Get the size of the input history.
+   *
+   * @return the number of inputs in the history.
    */
   public int size() {
     return inputHistory.size();
@@ -123,6 +137,8 @@ public class InputNavigation {
 
   /**
    * Update the current cursor position in the input history.
+   *
+   * @param position the new cursor position.
    */
   public void updateCursorPosition(int position) {
     if (position < 0 || position > inputHistory.size()) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/BuiltInChatModeService.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/BuiltInChatModeService.java
@@ -28,6 +28,8 @@ public class BuiltInChatModeService {
    *
    * <p>Note: The LSP requires workspace folders to be passed even for loading built-in modes. While built-in modes
    * don't depend on workspace context, the LSP API enforces this parameter.
+   *
+   * @return a future containing the loaded built-in chat modes.
    */
   public CompletableFuture<List<BuiltInChatMode>> loadBuiltInModes() {
     ConversationModesParams params = new ConversationModesParams(Collections.emptyList());

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IChatServiceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IChatServiceManager.java
@@ -10,16 +10,22 @@ public interface IChatServiceManager {
 
   /**
    * Get the referenced file service.
+   *
+   * @return the referenced file service.
    */
   IReferencedFileService getReferencedFileService();
 
   /**
    * Get the MCP config service.
+   *
+   * @return the MCP config service.
    */
   IMcpConfigService getMcpConfigService();
 
   /**
    * Get the customization file service tracking skill/prompt/instruction/agent file locations.
+   *
+   * @return the customization file service.
    */
   ICustomizationFileService getCustomizationFileService();
 }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/ICustomizationFileService.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/ICustomizationFileService.java
@@ -21,6 +21,8 @@ public interface ICustomizationFileService {
   /**
    * Returns the absolute paths of single-file customization files (prompts, instructions, agents).
    * The returned set is an immutable snapshot.
+   *
+   * @return the absolute paths of single-file customization files.
    */
   Set<Path> getCustomizationFiles();
 
@@ -28,6 +30,8 @@ public interface ICustomizationFileService {
    * Returns the absolute paths of skill folders (the directory containing each {@code SKILL.md}).
    * A read of any file within one of these folders is a skill read. The returned set is an immutable
    * snapshot.
+   *
+   * @return the absolute paths of skill folders.
    */
   Set<Path> getSkillFolders();
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IMcpConfigService.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IMcpConfigService.java
@@ -14,6 +14,9 @@ import com.microsoft.copilot.eclipse.core.lsp.mcp.McpOauthRequest;
 public interface IMcpConfigService {
   /**
    * Handles the Dynamic OAuth request from MCP servers.
+   *
+   * @param request the OAuth request from the MCP server.
+   * @return the OAuth response values.
    */
   Map<String, String> mcpOauth(McpOauthRequest request);
 }

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IReferencedFileService.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/chat/service/IReferencedFileService.java
@@ -16,11 +16,15 @@ import org.eclipse.lsp4j.Range;
 public interface IReferencedFileService {
   /**
    * Get the current file being referenced in the Copilot chat.
+   *
+   * @return the current referenced file.
    */
   IFile getCurrentFile();
 
   /**
    * Get the referenced files that is attached by user.
+   *
+   * @return the referenced files attached by the user.
    */
   List<IResource> getReferencedFiles();
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/CompletionListener.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/CompletionListener.java
@@ -14,6 +14,9 @@ public interface CompletionListener {
 
   /**
    * Notifies to the listeners when the completion is resolved.
+   *
+   * @param uriString the URI string for the document whose completion was resolved.
+   * @param completions the resolved completion items.
    */
   void onCompletionResolved(String uriString, List<CompletionItem> completions);
 

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/CompletionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/CompletionProvider.java
@@ -64,6 +64,9 @@ public class CompletionProvider {
 
   /**
    * Creates a new completion provider.
+   *
+   * @param lsConnection the language server connection used to request completions.
+   * @param statusManager the authentication status manager.
    */
   public CompletionProvider(CopilotLanguageServerConnection lsConnection, AuthStatusManager statusManager) {
     this.statusManager = statusManager;
@@ -76,6 +79,7 @@ public class CompletionProvider {
   /**
    * Trigger an inline completion.
    *
+   * @param file the file to request completion for.
    * @param position the position of the cursor.
    * @param documentVersion the version of the document.
    * @param enableNes whether NES is enabled
@@ -113,6 +117,8 @@ public class CompletionProvider {
 
   /**
    * Add a completion listener.
+   *
+   * @param listener the listener to add.
    */
   public void addCompletionListener(CompletionListener listener) {
     this.completionListeners.add(listener);
@@ -120,6 +126,8 @@ public class CompletionProvider {
 
   /**
    * Remove a completion listener.
+   *
+   * @param listener the listener to remove.
    */
   public void removeCompletionListener(CompletionListener listener) {
     this.completionListeners.remove(listener);
@@ -141,6 +149,8 @@ public class CompletionProvider {
 
     /**
      * Creates a new completion job.
+     *
+     * @param lsConnection the language server connection used to request completions.
      */
     public CompletionJob(CopilotLanguageServerConnection lsConnection) {
       super("Generating completion...");

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/SuggestionUpdateManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/completion/SuggestionUpdateManager.java
@@ -45,6 +45,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Creates a new SuggestionUpdateManager.
+   *
+   * @param document the document whose suggestions are being updated.
    */
   public SuggestionUpdateManager(IDocument document) {
     this.document = document;
@@ -57,6 +59,7 @@ public class SuggestionUpdateManager {
   /**
    * When user type new input, update the suggestion list based on the user input.
    *
+   * @param text the inserted text.
    * @return <code>true</code> if the update is accepted, <code>false</code> otherwise.
    */
   public boolean insert(String text) {
@@ -97,6 +100,7 @@ public class SuggestionUpdateManager {
   /**
    * When user delete characters, update the suggestion list based on the user input.
    *
+   * @param deletedCount the number of deleted characters.
    * @return true if the update is accepted, false otherwise
    */
   public boolean delete(int deletedCount) {
@@ -135,6 +139,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Get the next word for the current active completion item.
+   *
+   * @return the next word from the current active completion item.
    */
   public String getNextWord() {
     CompletionItem item = getCurrentItem();
@@ -182,6 +188,8 @@ public class SuggestionUpdateManager {
   /**
    * Initialize the completion items when the suggestion is resolved. It will do a entire flush when the original items
    * are empty. Otherwise, it will only update the updated items as a correction.
+   *
+   * @param items the completion items to set.
    */
   public void setCompletionItems(List<CompletionItem> items) {
     if (originalItems == null || originalItems.isEmpty()) {
@@ -206,6 +214,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Get the current active completion item. return null if there is no active item.
+   *
+   * @return the current active completion item, or null if there is no active item.
    */
   public CompletionItem getCurrentItem() {
     if (this.updatedItems.isEmpty()) {
@@ -219,6 +229,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Get the text of the current active completion item.
+   *
+   * @return the display text of the current active completion item.
    */
   public String getText() {
     CompletionItem item = getCurrentItem();
@@ -230,6 +242,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Get the first line of the current active completion item.
+   *
+   * @return the first line of the current active completion item.
    */
   public String getFirstLine() {
     String text = getText();
@@ -241,6 +255,8 @@ public class SuggestionUpdateManager {
 
   /**
    * Get the remaining lines of the current active completion item.
+   *
+   * @return the remaining lines of the current active completion item.
    */
   public String getRemainingLines() {
     String text = getText();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/CdtFormatReader.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/CdtFormatReader.java
@@ -29,6 +29,8 @@ public class CdtFormatReader extends LanguageFormatReader {
 
   /**
    * Creates a new CdtFormatReader for the given project.
+   *
+   * @param project the project whose C/C++ formatting preferences are read.
    */
   public CdtFormatReader(IProject project) {
     this.project = project;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/FormatOptionProvider.java
@@ -57,6 +57,9 @@ public class FormatOptionProvider {
    * Determines if indentation should use spaces. Copilot will attempt to retrieve the format options from the project
    * preferences. If the project preferences are not set, Copilot will use the workspace preferences. If the workspace
    * preferences are also not set, Copilot will default to using spaces.
+   *
+   * @param file the file whose indentation preferences are requested.
+   * @return true if indentation should use spaces.
    */
   public boolean useSpace(IFile file) {
     FormattingOptions languageFormat = getLanguageFormat(file);
@@ -67,6 +70,9 @@ public class FormatOptionProvider {
    * Retrieves the tab size for indentation. Copilot first attempts to get the format options from the project
    * preferences. If the project preferences are not set, it will use the workspace preferences. If the workspace
    * preferences are also not set, it defaults to a tab size of 4.
+   *
+   * @param file the file whose tab size preferences are requested.
+   * @return the tab size for indentation.
    */
   public int getTabSize(IFile file) {
     FormattingOptions languageFormat = getLanguageFormat(file);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/JavaFormatReader.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/format/JavaFormatReader.java
@@ -27,6 +27,8 @@ public class JavaFormatReader extends LanguageFormatReader {
 
   /**
    * Creates a new JavaFormatReader for the given project.
+   *
+   * @param project the project whose Java formatting preferences are read.
    */
   public JavaFormatReader(IProject project) {
     this.project = project;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/logger/CopilotForEclipseLogger.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/logger/CopilotForEclipseLogger.java
@@ -34,6 +34,8 @@ public class CopilotForEclipseLogger {
 
   /**
    * Log level.
+   *
+   * @param message the message to log.
    */
   public void info(String message) {
     LogRecord logRecord = new LogRecord(Level.INFO, message);
@@ -43,6 +45,9 @@ public class CopilotForEclipseLogger {
 
   /**
    * Log level.
+   *
+   * @param message the message to log.
+   * @param ex the exception to log.
    */
   public void error(String message, Throwable ex) {
     LogRecord logRecord = new LogRecord(Level.SEVERE, message);
@@ -52,6 +57,8 @@ public class CopilotForEclipseLogger {
 
   /**
    * Log level.
+   *
+   * @param ex the exception to log.
    */
   public void error(Throwable ex) {
     LogRecord logRecord = new LogRecord(Level.SEVERE, ex.getMessage());

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/logger/handlers/EclipseConsoleHandler.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/logger/handlers/EclipseConsoleHandler.java
@@ -21,6 +21,8 @@ public class EclipseConsoleHandler extends Handler {
 
   /**
    * Constructor.
+   *
+   * @param logger the Eclipse logger to receive log records.
    */
   public EclipseConsoleHandler(ILog logger) {
     this.logger = logger;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageClient.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageClient.java
@@ -104,6 +104,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Get the conversation context for the given request.
+   *
+   * @param params the conversation context request parameters.
+   * @return the conversation context result and optional response error.
    */
   @JsonRequest("conversation/context")
   public CompletableFuture<Object[]> getConversationContext(ConversationContextParams params) {
@@ -134,6 +137,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Invokes a client tool from the server.
+   *
+   * @param params the client tool invocation parameters.
+   * @return the tool invocation result.
    */
   @JsonRequest("conversation/invokeClientTool")
   public CompletableFuture<Object> invokeClientTool(InvokeClientToolParams params) {
@@ -163,6 +169,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Prompt for user confirmation before invoking a tool.
+   *
+   * @param params the client tool confirmation parameters.
+   * @return the confirmation result and optional response error.
    */
   @JsonRequest("conversation/invokeClientToolConfirmation")
   public CompletableFuture<Object[]> confirmClientTool(InvokeClientToolConfirmationParams params) {
@@ -206,6 +215,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when mcp server/tool change.
+   *
+   * @param params the MCP server and tool change parameters.
    */
   @JsonNotification("copilot/mcpTools")
   public void mcpTools(OnChangeMcpServerToolsParams params) {
@@ -216,6 +227,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when mcp runtime logs are available.
+   *
+   * @param mcpRuntimeLog the MCP runtime log notification.
    */
   @JsonNotification("copilot/mcpRuntimeLogs")
   public void mcpRuntimeLogs(McpRuntimeLog mcpRuntimeLog) {
@@ -226,6 +239,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when rate limit usage warning is received from the language server.
+   *
+   * @param params the rate limit warning parameters.
    */
   @JsonNotification("$/copilot/rateLimitWarning")
   public void onRateLimitWarning(RateLimitWarningParams params) {
@@ -236,6 +251,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when custom skills change (global or workspace).
+   *
+   * @param params the custom skill change notification parameters.
    */
   @JsonNotification("copilot/customSkill/didChange")
   public void onDidChangeCustomSkill(Object params) {
@@ -244,6 +261,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when custom prompts change (global or workspace).
+   *
+   * @param params the custom prompt change notification parameters.
    */
   @JsonNotification("copilot/customPrompt/didChange")
   public void onDidChangeCustomPrompt(Object params) {
@@ -252,6 +271,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when custom instructions change (global or workspace).
+   *
+   * @param params the custom instruction change notification parameters.
    */
   @JsonNotification("copilot/customInstruction/didChange")
   public void onDidChangeCustomInstruction(Object params) {
@@ -260,6 +281,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when custom agents change (global or workspace).
+   *
+   * @param params the custom agent change notification parameters.
    */
   @JsonNotification("copilot/customAgent/didChange")
   public void onDidChangeCustomAgent(Object params) {
@@ -277,6 +300,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
   /**
    * Handles the Dynamic OAuth request for MCP. Shows a dialog with multiple input fields and returns the user's input
    * values. Returns null if the user cancels the request.
+   *
+   * @param request the dynamic OAuth request from the MCP server.
+   * @return the user-provided OAuth values, or {@code null} if the request is cancelled.
    */
   @JsonRequest("copilot/dynamicOAuth")
   public CompletableFuture<Map<String, String>> mcpOauth(McpOauthRequest request) {
@@ -292,6 +318,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when feature flags change. This is used to update the UI based on the feature flags.
+   *
+   * @param params the updated feature flag parameters.
    */
   @JsonNotification("copilot/didChangeFeatureFlags")
   public void onDidChangeFeatureFlags(DidChangeFeatureFlagsParams params) {
@@ -311,6 +339,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when policy changes.
+   *
+   * @param params the updated policy parameters.
    */
   @JsonNotification("policy/didChange")
   public void onDidChangePolicy(DidChangePolicyParams params) {
@@ -337,6 +367,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Handles coding agent messages from the server.
+   *
+   * @param message the coding agent message request from the server.
+   * @return the coding agent message result.
    */
   @JsonRequest("copilot/codingAgentMessage")
   public CompletableFuture<CodingAgentMessageResult> onCodingAgentMessage(CodingAgentMessageRequestParams message) {
@@ -351,6 +384,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when a quota warning is received from the language server.
+   *
+   * @param params the quota warning parameters.
    */
   @JsonNotification("copilot/quotaWarning")
   public void onQuotaWarning(QuotaWarningParams params) {
@@ -361,6 +396,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when automatic conversation compression starts.
+   *
+   * @param params the compression started parameters.
    */
   @JsonNotification("$/copilot/compressionStarted")
   public void onCompressionStarted(CompressionStartedParams params) {
@@ -371,6 +408,8 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Notify when automatic conversation compression completes.
+   *
+   * @param params the compression completed parameters.
    */
   @JsonNotification("$/copilot/compressionCompleted")
   public void onCompressionCompleted(CompressionCompletedParams params) {
@@ -381,6 +420,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Reads the contents and stats of a file given its URI.
+   *
+   * @param uri the URI of the file to read.
+   * @return the file contents and stats.
    */
   @JsonRequest("workspace/readFile")
   public CompletableFuture<ReadFileResult> readFile(String uri) {
@@ -390,6 +432,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
   /**
    * Reads the contents of a directory given its URI. Used by the language server to list directory entries for URIs
    * with external content provider schemes (e.g., semanticfs://) that cannot be read from the local file system.
+   *
+   * @param uri the URI of the directory to read.
+   * @return the directory entries.
    */
   @JsonRequest("workspace/readDirectory")
   public CompletableFuture<ReadDirectoryResult> readDirectory(String uri) {
@@ -398,6 +443,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Searches for files matching a glob pattern under the given base URI.
+   *
+   * @param params the file search parameters.
+   * @return the matching files.
    */
   @JsonRequest("workspace/findFiles")
   public CompletableFuture<FindFilesResult> findFiles(FindFilesParams params) {
@@ -406,6 +454,9 @@ public class CopilotLanguageClient extends LanguageClientImpl {
 
   /**
    * Searches for text (or a regex) in files under the given base URI.
+   *
+   * @param params the text search parameters.
+   * @return the matching text search results.
    */
   @JsonRequest("workspace/findTextInFiles")
   public CompletableFuture<FindTextInFilesResult> findTextInFiles(FindTextInFilesParams params) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServer.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServer.java
@@ -82,7 +82,7 @@ public interface CopilotLanguageServer extends LanguageServer {
   CompletableFuture<CopilotStatusResult> checkStatus(CheckStatusParams param);
 
   /**
-   * Check the uesr's quota status.
+   * Check the user's quota status.
    *
    * @param param the empty quota request parameters.
    * @return the current quota status.

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServer.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServer.java
@@ -74,72 +74,108 @@ public interface CopilotLanguageServer extends LanguageServer {
 
   /**
    * Check the login status for current machine.
+   *
+   * @param param the status check options.
+   * @return the current Copilot status.
    */
   @JsonRequest
   CompletableFuture<CopilotStatusResult> checkStatus(CheckStatusParams param);
 
   /**
    * Check the uesr's quota status.
+   *
+   * @param param the empty quota request parameters.
+   * @return the current quota status.
    */
   @JsonRequest
   CompletableFuture<CheckQuotaResult> checkQuota(NullParams param);
 
   /**
    * Get single completion for the given parameters.
+   *
+   * @param params the completion request parameters.
+   * @return the completion result.
    */
   @JsonRequest
   CompletableFuture<CompletionResult> getCompletions(CompletionParams params);
 
   /**
    * Initiate the sign in process.
+   *
+   * @param param the empty sign-in initiation parameters.
+   * @return the sign-in initiation result.
    */
   @JsonRequest
   CompletableFuture<SignInInitiateResult> signInInitiate(NullParams param);
 
   /**
    * Confirm the sign in process.
+   *
+   * @param param the sign-in confirmation parameters.
+   * @return the updated Copilot status.
    */
   @JsonRequest
   CompletableFuture<CopilotStatusResult> signInConfirm(SignInConfirmParams param);
 
   /**
    * Sign out the current user.
+   *
+   * @param params the empty sign-out request parameters.
+   * @return the updated Copilot status.
    */
   @JsonRequest
   CompletableFuture<CopilotStatusResult> signOut(NullParams params);
 
   /**
    * Notify the language server that the completion was shown.
+   *
+   * @param params the shown completion notification parameters.
+   * @return the notification acknowledgement.
    */
   @JsonRequest
   CompletableFuture<String> notifyShown(NotifyShownParams params);
 
   /**
    * Notify the language server that the completion was accepted.
+   *
+   * @param params the accepted completion notification parameters.
+   * @return the notification acknowledgement.
    */
   @JsonRequest
   CompletableFuture<String> notifyAccepted(NotifyAcceptedParams params);
 
   /**
    * Notify the language server that the completion was rejected.
+   *
+   * @param params the rejected completion notification parameters.
+   * @return the notification acknowledgement.
    */
   @JsonRequest
   CompletableFuture<String> notifyRejected(NotifyRejectedParams params);
 
   /**
    * Send exception telemetry to github sentry.
+   *
+   * @param params the exception telemetry parameters.
+   * @return the telemetry request result.
    */
   @JsonRequest("telemetry/exception")
   CompletableFuture<Object> sendExceptionTelemetry(TelemetryExceptionParams params);
 
   /**
    * Create a new conversation.
+   *
+   * @param param the conversation creation parameters.
+   * @return the created conversation result.
    */
   @JsonRequest("conversation/create")
   CompletableFuture<ChatCreateResult> create(ConversationCreateParams param);
 
   /**
    * Create a new conversation.
+   *
+   * @param param the conversation turn parameters.
+   * @return the conversation turn result.
    */
   @JsonRequest("conversation/turn")
   CompletableFuture<ChatTurnResult> addTurn(ConversationTurnParams param);
@@ -148,6 +184,8 @@ public interface CopilotLanguageServer extends LanguageServer {
    * List conversation templates.
    *
    * @param params includes workspace folders for discovering workspace-specific prompt files and skills
+   *
+   * @return the available conversation templates.
    */
   @JsonRequest("conversation/templates")
   CompletableFuture<ConversationTemplate[]> listTemplates(WorkspaceFoldersParams params);
@@ -156,6 +194,8 @@ public interface CopilotLanguageServer extends LanguageServer {
    * List custom skill files (each carries its on-disk {@code uri}).
    *
    * @param params includes the workspace folders to scan
+   *
+   * @return the available custom skill files.
    */
   @JsonRequest("copilot/customSkill/list")
   CompletableFuture<CustomizationFileInfo[]> listCustomSkills(WorkspaceFoldersParams params);
@@ -164,6 +204,8 @@ public interface CopilotLanguageServer extends LanguageServer {
    * List custom prompt files (each carries its on-disk {@code uri}).
    *
    * @param params includes the workspace folders to scan
+   *
+   * @return the available custom prompt files.
    */
   @JsonRequest("copilot/customPrompt/list")
   CompletableFuture<CustomizationFileInfo[]> listCustomPrompts(WorkspaceFoldersParams params);
@@ -172,6 +214,8 @@ public interface CopilotLanguageServer extends LanguageServer {
    * List custom instruction files (each carries its on-disk {@code uri}).
    *
    * @param params includes the workspace folders to scan
+   *
+   * @return the available custom instruction files.
    */
   @JsonRequest("copilot/customInstruction/list")
   CompletableFuture<CustomizationFileInfo[]> listCustomInstructions(WorkspaceFoldersParams params);
@@ -180,102 +224,152 @@ public interface CopilotLanguageServer extends LanguageServer {
    * List custom agent files (each carries its on-disk {@code uri}).
    *
    * @param params includes the workspace folders to scan
+   *
+   * @return the available custom agent files.
    */
   @JsonRequest("copilot/customAgent/list")
   CompletableFuture<CustomizationFileInfo[]> listCustomAgents(WorkspaceFoldersParams params);
 
   /**
    * List conversation modes.
+   *
+   * @param params the conversation mode request parameters.
+   * @return the available conversation modes.
    */
   @JsonRequest("conversation/modes")
   CompletableFuture<ConversationMode[]> listModes(ConversationModesParams params);
 
   /**
    * Used to track telemetry from users copying code from chat.
+   *
+   * @param param the copied code telemetry parameters.
+   * @return the telemetry request acknowledgement.
    */
   @JsonRequest("conversation/copyCode")
   CompletableFuture<String> copyCode(ConversationCodeCopyParams param);
 
   /**
    * Used to get the persistence token for the current user.
+   *
+   * @param param the empty persistence request parameters.
+   * @return the chat persistence token information.
    */
   @JsonRequest("conversation/persistence")
   CompletableFuture<ChatPersistence> persistence(NullParams param);
 
   /**
    * Destroy a conversation, stopping any in-progress processing.
+   *
+   * @param param the conversation destroy parameters.
+   * @return the destroy request acknowledgement.
    */
   @JsonRequest("conversation/destroy")
   CompletableFuture<String> destroy(ConversationDestroyParams param);
 
   /**
    * Register agent tools to the language server.
+   *
+   * @param params the tool registration parameters.
+   * @return the registered language model tool information.
    */
   @JsonRequest("conversation/registerTools")
   CompletableFuture<List<LanguageModelToolInformation>> registerTools(RegisterToolsParams params);
 
   /**
    * Update the status of conversation tools (built-in tools for Agent mode).
+   *
+   * @param params the conversation tool status parameters.
+   * @return the update request result.
    */
   @JsonRequest("conversation/updateToolsStatus")
   CompletableFuture<Object> updateConversationToolsStatus(UpdateConversationToolsStatusParams params);
 
   /**
    * List copilot models.
+   *
+   * @param param the empty model list request parameters.
+   * @return the available Copilot models.
    */
   @JsonRequest("copilot/models")
   CompletableFuture<CopilotModel[]> listModels(NullParams param);
 
   /**
    * Notify the code acceptance.
+   *
+   * @param params the code acceptance notification parameters.
+   * @return the notification acknowledgement.
    */
   @JsonRequest("conversation/notifyCodeAcceptance")
   CompletableFuture<String> notifyCodeAcceptance(NotifyCodeAcceptanceParams params);
 
   /**
    * Generate commit messages.
+   *
+   * @param params the commit message generation parameters.
+   * @return the generated commit message result.
    */
   @JsonRequest("git/commitGenerate")
   CompletableFuture<GenerateCommitMessageResult> generateCommitMessage(GenerateCommitMessageParams params);
 
   /**
    * Generate a short title summarizing a thinking block.
+   *
+   * @param params the thinking title generation parameters.
+   * @return the generated thinking title response.
    */
   @JsonRequest("thinking/generateTitle")
   CompletableFuture<GenerateThinkingTitleResponse> generateThinkingTitle(GenerateThinkingTitleParams params);
 
   /**
    * List BYOK models.
+   *
+   * @param params the BYOK model list request parameters.
+   * @return the BYOK model list response.
    */
   @JsonRequest("copilot/byok/listModels")
   CompletableFuture<ByokListModelResponse> listByokModels(ByokListModelParams params);
 
   /**
    * Save BYOK model.
+   *
+   * @param model the BYOK model to save.
+   * @return the BYOK save status response.
    */
   @JsonRequest("copilot/byok/saveModel")
   CompletableFuture<ByokStatusResponse> saveByokModel(ByokModel model);
 
   /**
    * Delete BYOK model.
+   *
+   * @param model the BYOK model to delete.
+   * @return the BYOK delete status response.
    */
   @JsonRequest("copilot/byok/deleteModel")
   CompletableFuture<ByokStatusResponse> deleteByokModel(ByokModel model);
 
   /**
    * Save BYOK API key.
+   *
+   * @param apiKey the BYOK API key to save.
+   * @return the BYOK save status response.
    */
   @JsonRequest("copilot/byok/saveApiKey")
   CompletableFuture<ByokStatusResponse> saveByokApiKey(ByokApiKey apiKey);
 
   /**
    * Delete BYOK API key.
+   *
+   * @param apiKey the BYOK API key to delete.
+   * @return the BYOK delete status response.
    */
   @JsonRequest("copilot/byok/deleteApiKey")
   CompletableFuture<ByokStatusResponse> deleteByokApiKey(ByokApiKey apiKey);
 
   /**
    * List All BYOK API keys.
+   *
+   * @param apiKey the BYOK API key filter parameters.
+   * @return the BYOK API key list response.
    */
   @JsonRequest("copilot/byok/listApiKeys")
   CompletableFuture<ByokListApiKeyResponse> listByokApiKeys(ByokApiKey apiKey);
@@ -300,42 +394,63 @@ public interface CopilotLanguageServer extends LanguageServer {
 
   /**
    * Update the status of the mcp server and tools.
+   *
+   * @param param the MCP tool status update parameters.
+   * @return the updated MCP server tool collections.
    */
   @JsonRequest("mcp/updateToolsStatus")
   CompletableFuture<List<McpServerToolsCollection>> updateMcpToolsStatus(UpdateMcpToolsStatusParams param);
 
   /**
    * Get the MCP server list.
+   *
+   * @param params the MCP server list request parameters.
+   * @return the MCP server list.
    */
   @JsonRequest("mcp/registry/listServers")
   CompletableFuture<ServerList> listMcpServers(ListServersParams params);
 
   /**
    * Get the details of a specific MCP server.
+   *
+   * @param params the MCP server details request parameters.
+   * @return the MCP server details response.
    */
   @JsonRequest("mcp/registry/getServer")
   CompletableFuture<ServerResponse> getMcpServer(GetServerParams params);
 
   /**
    * Get the MCP registry allowlist for the current user or organization.
+   *
+   * @param params the MCP allowlist request parameters.
+   * @return the MCP registry allowlist.
    */
   @JsonRequest("mcp/registry/getAllowlist")
   CompletableFuture<McpRegistryAllowList> getMcpAllowlist(Object params);
 
   /**
    * Next Edit Suggestions request.
+   *
+   * @param params the next edit suggestion request parameters.
+   * @return the next edit suggestion result.
    */
   @JsonRequest("textDocument/copilotInlineEdit")
   CompletableFuture<NextEditSuggestionsResult> getNextEditSuggestions(NextEditSuggestionsParams params);
 
   /**
    * Search GitHub Pull Requests.
+   *
+   * @param params the GitHub pull request search parameters.
+   * @return the GitHub pull request search response.
    */
   @JsonRequest("githubApi/searchPR")
   CompletableFuture<SearchPrResponse> searchPr(SearchPrParams params);
 
   /**
    * Get the default file safety rules from CLS.
+   *
+   * @param params the empty default file safety rules request parameters.
+   * @return the default file safety rules result.
    */
   @JsonRequest("getDefaultFileSafetyRules")
   CompletableFuture<GetDefaultFileSafetyRulesResult> getDefaultFileSafetyRules(
@@ -343,6 +458,8 @@ public interface CopilotLanguageServer extends LanguageServer {
 
   /**
    * Notify that an inline edit was shown.
+   *
+   * @param params the inline edit shown notification parameters.
    */
   @JsonNotification("textDocument/didShowInlineEdit")
   void didShowInlineEdit(DidShowInlineEditParams params);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/CopilotLanguageServerConnection.java
@@ -109,6 +109,10 @@ public class CopilotLanguageServerConnection {
   /**
    * Connect the document to the language server. The LSP4E will take care of all the document lifecycle events after
    * that.
+   *
+   * @param document the document to connect.
+   * @param file the workspace file backing the document.
+   * @return a future for the connected language server wrapper.
    */
   public CompletableFuture<LanguageServerWrapper> connectDocument(IDocument document, IFile file) {
     try {
@@ -121,6 +125,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Disconnect the document from the language server.
+   *
+   * @param uri the URI of the document to disconnect.
    */
   public void disconnectDocument(URI uri) {
     this.languageServerWrapper.disconnect(uri);
@@ -128,6 +134,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get the document version for the given URI.
+   *
+   * @param uri the URI of the document.
+   * @return the current text document version.
    */
   public int getDocumentVersion(URI uri) {
     return this.languageServerWrapper.getTextDocumentVersion(uri);
@@ -135,6 +144,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Check the login status for current machine.
+   *
+   * @param localCheckOnly whether to run only local status checks.
+   * @return the current Copilot status.
    */
   public CompletableFuture<CopilotStatusResult> checkStatus(Boolean localCheckOnly) {
     Function<LanguageServer, CompletableFuture<CopilotStatusResult>> fn = server -> {
@@ -147,6 +159,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Check the user's quota status.
+   *
+   * @return the current quota status.
    */
   public CompletableFuture<CheckQuotaResult> checkQuota() {
     Function<LanguageServer, CompletableFuture<CheckQuotaResult>> fn = server -> ((CopilotLanguageServer) server)
@@ -156,6 +170,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get the default file safety rules from CLS.
+   *
+   * @return the default file safety rules result.
    */
   public CompletableFuture<GetDefaultFileSafetyRulesResult> getDefaultFileSafetyRules() {
     Function<LanguageServer, CompletableFuture<GetDefaultFileSafetyRulesResult>> fn =
@@ -166,6 +182,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get single completion for the given parameters.
+   *
+   * @param params the completion request parameters.
+   * @return the completion result.
    */
   public CompletableFuture<CompletionResult> getCompletions(CompletionParams params) {
     Function<LanguageServer, CompletableFuture<CompletionResult>> fn = server -> ((CopilotLanguageServer) server)
@@ -175,6 +194,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Update the configuration for the language server.
+   *
+   * @param params the updated configuration parameters.
    */
   public void updateConfig(DidChangeConfigurationParams params) {
     this.languageServerWrapper.sendNotification(server -> server.getWorkspaceService().didChangeConfiguration(params));
@@ -184,6 +205,8 @@ public class CopilotLanguageServerConnection {
    * Please use the {@link CopilotStatusManager#signInInitiate()} method instead.
    * </p>
    * Initiate the sign in process.
+   *
+   * @return the sign-in initiation result.
    */
   public CompletableFuture<SignInInitiateResult> signInInitiate() {
     Function<LanguageServer, CompletableFuture<SignInInitiateResult>> fn = (server) -> ((CopilotLanguageServer) server)
@@ -195,6 +218,9 @@ public class CopilotLanguageServerConnection {
    * Please use the {@link AuthStatusManager#signInConfirm()} method instead.
    * </p>
    * Confirm the sign in process.
+   *
+   * @param userCode the user code returned by the sign-in flow.
+   * @return the updated Copilot status.
    */
   public CompletableFuture<CopilotStatusResult> signInConfirm(String userCode) {
     Function<LanguageServer, CompletableFuture<CopilotStatusResult>> fn = (server) -> {
@@ -208,6 +234,8 @@ public class CopilotLanguageServerConnection {
    * Please use the {@link AuthStatusManager#signOut()} method instead.
    * </p>
    * Sign out from the GitHub Copilot.
+   *
+   * @return the updated Copilot status.
    */
   public CompletableFuture<CopilotStatusResult> signOut() {
     Function<LanguageServer, CompletableFuture<CopilotStatusResult>> fn = (server) -> ((CopilotLanguageServer) server)
@@ -217,6 +245,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Notify the language server that the completion was shown.
+   *
+   * @param params the shown completion notification parameters.
+   * @return the notification acknowledgement.
    */
   public CompletableFuture<String> notifyShown(NotifyShownParams params) {
     Function<LanguageServer, CompletableFuture<String>> fn = server -> ((CopilotLanguageServer) server)
@@ -229,6 +260,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Notify the language server that the completion was accepted.
+   *
+   * @param params the accepted completion notification parameters.
+   * @return the notification acknowledgement.
    */
   public CompletableFuture<String> notifyAccepted(NotifyAcceptedParams params) {
     Function<LanguageServer, CompletableFuture<String>> fn = server -> ((CopilotLanguageServer) server)
@@ -241,6 +275,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Notify the language server that the completion was rejected.
+   *
+   * @param params the rejected completion notification parameters.
+   * @return the notification acknowledgement.
    */
   public CompletableFuture<String> notifyRejected(NotifyRejectedParams params) {
     Function<LanguageServer, CompletableFuture<String>> fn = server -> ((CopilotLanguageServer) server)
@@ -253,6 +290,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Send the exception telemetry to the language server.
+   *
+   * @param ex the exception to report.
+   * @return the telemetry request result.
    */
   public CompletableFuture<Object> sendExceptionTelemetry(Throwable ex) {
     TelemetryExceptionParams telemParams = new TelemetryExceptionParams(ex);
@@ -267,6 +307,24 @@ public class CopilotLanguageServerConnection {
   /**
    * Create a conversation with the given parameters, including an optional reasoning effort and context-window size to
    * forward to the server via {@code modelInfo}.
+   *
+   * @param workDoneToken the progress token for the conversation request.
+   * @param message the user message that starts the conversation.
+   * @param files the files referenced by the message.
+   * @param currentFile the current editor file, or {@code null} if none.
+   * @param currentSelection the current editor selection, or {@code null} if none.
+   * @param turns the previous conversation turns to restore, or {@code null} if none.
+   * @param activeModel the selected Copilot model.
+   * @param reasoningEffort the requested reasoning effort, or {@code null} if unset.
+   * @param chatModeName the selected chat mode name.
+   * @param customChatModeId the selected custom chat mode id, or {@code null} if none.
+   * @param todos the todo items to send with the conversation.
+   * @param agentSlug the selected agent slug, or blank for normal chat.
+   * @param agentJobWorkspaceFolder the workspace folder for an agent job.
+   * @param conversationId the conversation id to restore, or {@code null} for a new conversation.
+   * @param restoreToTurnId the turn id to restore to, or {@code null} if not restoring.
+   * @param workspaceFolders the workspace folders available to the conversation.
+   * @return the created conversation result.
    */
   public CompletableFuture<ChatCreateResult> createConversation(String workDoneToken, String message,
       List<IResource> files, IFile currentFile, Range currentSelection, List<Turn> turns, CopilotModel activeModel,
@@ -325,6 +383,22 @@ public class CopilotLanguageServerConnection {
   /**
    * Create a conversation turn with the given parameters, including an optional reasoning effort and context-window
    * size to forward to the server via {@code modelInfo}.
+   *
+   * @param workDoneToken the progress token for the turn request.
+   * @param conversationId the conversation id receiving the turn.
+   * @param message the user message for the new turn.
+   * @param files the files referenced by the message.
+   * @param currentFile the current editor file, or {@code null} if none.
+   * @param currentSelection the current editor selection, or {@code null} if none.
+   * @param activeModel the selected Copilot model.
+   * @param reasoningEffort the requested reasoning effort, or {@code null} if unset.
+   * @param chatModeName the selected chat mode name.
+   * @param customChatModeId the selected custom chat mode id, or {@code null} if none.
+   * @param todoList the todo items to send with the turn.
+   * @param agentSlug the selected agent slug, or blank for normal chat.
+   * @param agentJobWorkspaceFolder the workspace folder for an agent job.
+   * @param workspaceFolders the workspace folders available to the turn.
+   * @return the conversation turn result.
    */
   public CompletableFuture<ChatTurnResult> addConversationTurn(String workDoneToken, String conversationId,
       String message, List<IResource> files, IFile currentFile, Range currentSelection, CopilotModel activeModel,
@@ -370,6 +444,8 @@ public class CopilotLanguageServerConnection {
    * List the conversation templates.
    *
    * @param workspaceFolders workspace folders for discovering workspace-specific prompt files and skills
+   *
+   * @return the available conversation templates.
    */
   public CompletableFuture<ConversationTemplate[]> listConversationTemplates(List<WorkspaceFolder> workspaceFolders) {
     Function<LanguageServer, CompletableFuture<ConversationTemplate[]>> fn = server -> {
@@ -382,6 +458,8 @@ public class CopilotLanguageServerConnection {
    * List custom skill files, each carrying its on-disk {@code uri}.
    *
    * @param workspaceFolders the workspace folders to scan
+   *
+   * @return the available custom skill files.
    */
   public CompletableFuture<CustomizationFileInfo[]> listCustomSkills(List<WorkspaceFolder> workspaceFolders) {
     return this.languageServerWrapper.execute(server ->
@@ -392,6 +470,8 @@ public class CopilotLanguageServerConnection {
    * List custom prompt files, each carrying its on-disk {@code uri}.
    *
    * @param workspaceFolders the workspace folders to scan
+   *
+   * @return the available custom prompt files.
    */
   public CompletableFuture<CustomizationFileInfo[]> listCustomPrompts(List<WorkspaceFolder> workspaceFolders) {
     return this.languageServerWrapper.execute(server ->
@@ -402,6 +482,8 @@ public class CopilotLanguageServerConnection {
    * List custom instruction files, each carrying its on-disk {@code uri}.
    *
    * @param workspaceFolders the workspace folders to scan
+   *
+   * @return the available custom instruction files.
    */
   public CompletableFuture<CustomizationFileInfo[]> listCustomInstructions(List<WorkspaceFolder> workspaceFolders) {
     return this.languageServerWrapper.execute(server ->
@@ -412,6 +494,8 @@ public class CopilotLanguageServerConnection {
    * List custom agent files, each carrying its on-disk {@code uri}.
    *
    * @param workspaceFolders the workspace folders to scan
+   *
+   * @return the available custom agent files.
    */
   public CompletableFuture<CustomizationFileInfo[]> listCustomAgents(List<WorkspaceFolder> workspaceFolders) {
     return this.languageServerWrapper.execute(server ->
@@ -420,6 +504,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * List the conversation modes.
+   *
+   * @param params the conversation mode request parameters.
+   * @return the available conversation modes.
    */
   public CompletableFuture<ConversationMode[]> listConversationModes(ConversationModesParams params) {
     Function<LanguageServer, CompletableFuture<ConversationMode[]>> fn = server -> {
@@ -430,6 +517,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Used to track telemetry from users copying code from chat.
+   *
+   * @param params the copied code telemetry parameters.
+   * @return the telemetry request acknowledgement.
    */
   public CompletableFuture<String> codeCopy(ConversationCodeCopyParams params) {
     Function<LanguageServer, CompletableFuture<String>> fn = server -> ((CopilotLanguageServer) server)
@@ -442,6 +532,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Used to get the persistence token for the current user.
+   *
+   * @return the chat persistence token information.
    */
   public CompletableFuture<ChatPersistence> persistence() {
     Function<LanguageServer, CompletableFuture<ChatPersistence>> fn = server -> ((CopilotLanguageServer) server)
@@ -454,6 +546,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Destroy a conversation, stopping any in-progress processing on the server.
+   *
+   * @param conversationId the conversation id to destroy.
    */
   public void destroyConversation(String conversationId) {
     if (StringUtils.isBlank(conversationId)) {
@@ -469,6 +563,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Used to register the tools for the language server.
+   *
+   * @param params the tool registration parameters.
+   * @return the registered language model tool information.
    */
   public CompletableFuture<List<LanguageModelToolInformation>> registerTools(RegisterToolsParams params) {
     // @formatter:off
@@ -483,6 +580,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * List the copilot models.
+   *
+   * @return the available Copilot models.
    */
   public CompletableFuture<CopilotModel[]> listModels() {
     Function<LanguageServer, CompletableFuture<CopilotModel[]>> fn = server -> {
@@ -493,6 +592,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Update the status of the mcp server and tools.
+   *
+   * @param params the MCP tool status update parameters.
+   * @return the updated MCP server tool collections.
    */
   public CompletableFuture<List<McpServerToolsCollection>> updateMcpToolsStatus(UpdateMcpToolsStatusParams params) {
     // @formatter:off
@@ -507,6 +609,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Update the status of conversation tools (built-in tools for Agent mode).
+   *
+   * @param params the conversation tool status parameters.
+   * @return the update request result.
    */
   public CompletableFuture<Object> updateConversationToolsStatus(UpdateConversationToolsStatusParams params) {
     Function<LanguageServer, CompletableFuture<Object>> fn = server -> ((CopilotLanguageServer) server)
@@ -519,6 +624,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Notify the language server about code acceptance.
+   *
+   * @param params the code acceptance notification parameters.
+   * @return the notification acknowledgement.
    */
   public CompletableFuture<String> notifyCodeAcceptance(NotifyCodeAcceptanceParams params) {
     Function<LanguageServer, CompletableFuture<String>> fn = server -> ((CopilotLanguageServer) server)
@@ -531,6 +639,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Generate a commit message based on the provided parameters.
+   *
+   * @param params the commit message generation parameters.
+   * @return the generated commit message result.
    */
   public CompletableFuture<GenerateCommitMessageResult> generateCommitMessage(GenerateCommitMessageParams params) {
     // @formatter:off
@@ -545,6 +656,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Generate a short title summarizing a thinking block.
+   *
+   * @param params the thinking title generation parameters.
+   * @return the generated thinking title response.
    */
   public CompletableFuture<GenerateThinkingTitleResponse> generateThinkingTitle(
       GenerateThinkingTitleParams params) {
@@ -558,6 +672,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * List BYOK models.
+   *
+   * @param params the BYOK model list request parameters.
+   * @return the BYOK model list response.
    */
   public CompletableFuture<ByokListModelResponse> listByokModels(ByokListModelParams params) {
     Function<LanguageServer, CompletableFuture<ByokListModelResponse>> fn = server -> {
@@ -568,6 +685,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Save a BYOK model.
+   *
+   * @param model the BYOK model to save.
+   * @return the BYOK save status response.
    */
   public CompletableFuture<ByokStatusResponse> saveByokModel(ByokModel model) {
     Function<LanguageServer, CompletableFuture<ByokStatusResponse>> fn = server -> {
@@ -578,6 +698,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Delete a BYOK model.
+   *
+   * @param model the BYOK model to delete.
+   * @return the BYOK delete status response.
    */
   public CompletableFuture<ByokStatusResponse> deleteByokModel(ByokModel model) {
     Function<LanguageServer, CompletableFuture<ByokStatusResponse>> fn = server -> {
@@ -588,6 +711,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * List all BYOK Api keys.
+   *
+   * @param apiKey the BYOK API key filter parameters.
+   * @return the BYOK API key list response.
    */
   public CompletableFuture<ByokListApiKeyResponse> listByokApiKeys(ByokApiKey apiKey) {
     Function<LanguageServer, CompletableFuture<ByokListApiKeyResponse>> fn = server -> {
@@ -629,6 +755,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Save a BYOK API key.
+   *
+   * @param apiKey the BYOK API key to save.
+   * @return the BYOK save status response.
    */
   public CompletableFuture<ByokStatusResponse> saveByokApiKey(ByokApiKey apiKey) {
     Function<LanguageServer, CompletableFuture<ByokStatusResponse>> fn = server -> {
@@ -639,6 +768,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Delete a BYOK API key.
+   *
+   * @param apiKey the BYOK API key to delete.
+   * @return the BYOK delete status response.
    */
   public CompletableFuture<ByokStatusResponse> deleteByokApiKey(ByokApiKey apiKey) {
     Function<LanguageServer, CompletableFuture<ByokStatusResponse>> fn = server -> {
@@ -649,6 +781,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get the MCP server list.
+   *
+   * @param params the MCP server list request parameters.
+   * @return the MCP server list.
    */
   public CompletableFuture<ServerList> listMcpServers(ListServersParams params) {
     Function<LanguageServer, CompletableFuture<ServerList>> fn = server -> ((CopilotLanguageServer) server)
@@ -658,6 +793,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get the details of a specific MCP server.
+   *
+   * @param params the MCP server details request parameters.
+   * @return the MCP server details response.
    */
   public CompletableFuture<ServerResponse> getMcpServer(GetServerParams params) {
     Function<LanguageServer, CompletableFuture<ServerResponse>> fn = server -> ((CopilotLanguageServer) server)
@@ -670,6 +808,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get the MCP registry allowlist for the current user or organization.
+   *
+   * @param params the MCP allowlist request parameters.
+   * @return the MCP registry allowlist.
    */
   public CompletableFuture<McpRegistryAllowList> getMcpAllowlist(Object params) {
     Function<LanguageServer, CompletableFuture<McpRegistryAllowList>> fn = server -> ((CopilotLanguageServer) server)
@@ -682,6 +823,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Get next edit suggestions (inline edit) for a position.
+   *
+   * @param params the next edit suggestion request parameters.
+   * @return the next edit suggestion result.
    */
   public CompletableFuture<NextEditSuggestionsResult> getNextEditSuggestions(NextEditSuggestionsParams params) {
     // @formatter:off
@@ -693,6 +837,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Search GitHub pull requests based on the given parameters.
+   *
+   * @param params the GitHub pull request search parameters.
+   * @return the GitHub pull request search response.
    */
   public CompletableFuture<SearchPrResponse> searchPr(SearchPrParams params) {
     Function<LanguageServer, CompletableFuture<SearchPrResponse>> fn = server -> ((CopilotLanguageServer) server)
@@ -702,6 +849,8 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Notify that an inline edit was shown.
+   *
+   * @param params the inline edit shown notification parameters.
    */
   public void didShowInlineEdit(DidShowInlineEditParams params) {
     this.languageServerWrapper.sendNotification(server -> ((CopilotLanguageServer) server).didShowInlineEdit(params));
@@ -709,6 +858,9 @@ public class CopilotLanguageServerConnection {
 
   /**
    * Accept the next edit suggestion (inline edit).
+   *
+   * @param command the command associated with the accepted suggestion.
+   * @return the command execution result.
    */
   public CompletableFuture<Object> acceptNextEditSuggestion(Command command) {
     if (command == null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionDocument.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionDocument.java
@@ -26,6 +26,9 @@ public class CompletionDocument extends TextDocumentIdentifier {
 
   /**
    * Create a new CompletionDocument.
+   *
+   * @param uri the document URI.
+   * @param position the cursor position for completion.
    */
   public CompletionDocument(@NonNull String uri, @NonNull Position position) {
     super(uri);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionItem.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionItem.java
@@ -35,6 +35,13 @@ public class CompletionItem {
 
   /**
    * Creates a new CompletionItem.
+   *
+   * @param uuid the unique identifier of the completion item.
+   * @param text the completion text to insert.
+   * @param range the document range the completion applies to.
+   * @param displayText the text to display for the completion item.
+   * @param position the cursor position associated with the completion.
+   * @param docVersion the version of the document for the completion.
    */
   public CompletionItem(@NonNull String uuid, @NonNull String text, @NonNull Range range, @NonNull String displayText,
       @NonNull Position position, @NonNull int docVersion) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionParams.java
@@ -21,6 +21,8 @@ public class CompletionParams {
 
   /**
    * Create a new parameter for getCompletion request.
+   *
+   * @param doc the document information for the completion request.
    */
   public CompletionParams(@NonNull CompletionDocument doc) {
     this.doc = doc;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CompletionResult.java
@@ -19,6 +19,8 @@ public class CompletionResult {
 
   /**
    * Creates a new CompletionResult.
+   *
+   * @param completions the completion items returned by the request.
    */
   public CompletionResult(@NonNull List<CompletionItem> completions) {
     this.completions = completions;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationCodeCopyParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationCodeCopyParams.java
@@ -36,6 +36,13 @@ public class ConversationCodeCopyParams {
 
   /**
    * Constructor for the ConversationCodeCopyParams.
+   *
+   * @param turnId the identifier of the conversation turn containing the copied code.
+   * @param codeBlockIndex the index of the copied code block within the turn.
+   * @param source the source of the copy action.
+   * @param copiedCharacters the number of copied characters.
+   * @param totalCharacters the total number of characters in the code block.
+   * @param copiedText the copied code text.
    */
   public ConversationCodeCopyParams(String turnId, int codeBlockIndex, String source, int copiedCharacters,
       int totalCharacters, String copiedText) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationCreateParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationCreateParams.java
@@ -45,6 +45,9 @@ public class ConversationCreateParams {
 
   /**
    * Creates a new ConversationCreateParams.
+   *
+   * @param prompt the initial prompt for the conversation.
+   * @param workDoneToken the work-done progress token for the conversation request.
    */
   public ConversationCreateParams(Either<String, List<ChatCompletionContentPart>> prompt, String workDoneToken) {
     this.workDoneToken = workDoneToken;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationDestroyParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationDestroyParams.java
@@ -15,6 +15,8 @@ public class ConversationDestroyParams {
 
   /**
    * Creates a new ConversationDestroyParams.
+   *
+   * @param conversationId the identifier of the conversation to destroy.
    */
   public ConversationDestroyParams(String conversationId) {
     this.conversationId = conversationId;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationError.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationError.java
@@ -68,6 +68,8 @@ public class ConversationError {
   /**
    * The name of the model provider that produced the error, when the failing request was routed to a custom
    * Bring-Your-Own-Key (BYOK) model. {@code null} or blank for built-in Copilot models.
+   *
+   * @return the name of the model provider that produced the error.
    */
   public String getModelProviderName() {
     return modelProviderName;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationTurnParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ConversationTurnParams.java
@@ -45,6 +45,10 @@ public class ConversationTurnParams {
 
   /**
    * Creates a new ConversationTurnParams.
+   *
+   * @param workDoneToken the work-done progress token for the conversation turn request.
+   * @param conversationId the identifier of the conversation receiving the turn.
+   * @param message the message content for the conversation turn.
    */
   public ConversationTurnParams(String workDoneToken, String conversationId,
       Either<String, List<ChatCompletionContentPart>> message) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CopilotAgentSettings.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CopilotAgentSettings.java
@@ -40,7 +40,11 @@ public class CopilotAgentSettings {
     private EditSettings edit;
     private McpSettings mcp = new McpSettings();
 
-    /** Gets terminal settings, creating if needed. */
+    /**
+     * Gets terminal settings, creating if needed.
+     *
+     * @return the terminal settings.
+     */
     public TerminalSettings getTerminal() {
       if (terminal == null) {
         terminal = new TerminalSettings();
@@ -48,7 +52,11 @@ public class CopilotAgentSettings {
       return terminal;
     }
 
-    /** Gets edit settings, creating if needed. */
+    /**
+     * Gets edit settings, creating if needed.
+     *
+     * @return the edit settings.
+     */
     public EditSettings getEdit() {
       if (edit == null) {
         edit = new EditSettings();
@@ -56,7 +64,11 @@ public class CopilotAgentSettings {
       return edit;
     }
 
-    /** Gets MCP settings, creating if needed. */
+    /**
+     * Gets MCP settings, creating if needed.
+     *
+     * @return the MCP settings.
+     */
     public McpSettings getMcp() {
       if (mcp == null) {
         mcp = new McpSettings();
@@ -263,7 +275,11 @@ public class CopilotAgentSettings {
     this.autoApproveUnmatchedFileOp = autoApproveUnmatchedFileOp;
   }
 
-  /** Gets tools settings, creating if needed. */
+  /**
+   * Gets tools settings, creating if needed.
+   *
+   * @return the tools settings.
+   */
   public ToolsSettings getTools() {
     if (tools == null) {
       tools = new ToolsSettings();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CopilotLanguageServerSettings.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CopilotLanguageServerSettings.java
@@ -373,6 +373,11 @@ public class CopilotLanguageServerSettings {
 
   /**
    * Constructor with parameters.
+   *
+   * @param enableAutoCompletions whether automatic completions are enabled.
+   * @param http the HTTP settings.
+   * @param githubEnterprise the GitHub Enterprise settings.
+   * @param githubSettings the GitHub settings.
    */
   public CopilotLanguageServerSettings(@Nullable Boolean enableAutoCompletions, @Nullable Http http,
       @Nullable GithubEnterprise githubEnterprise, @Nullable GitHubSettings githubSettings) {
@@ -465,6 +470,8 @@ public class CopilotLanguageServerSettings {
 
   /**
    * set mcp servers.
+   *
+   * @param mcpServersPreference the MCP servers preference value.
    */
   public void setMcpServers(String mcpServersPreference) {
     String mcpServers = parseMcpServers(mcpServersPreference);
@@ -473,6 +480,8 @@ public class CopilotLanguageServerSettings {
 
   /**
    * add mcp servers.
+   *
+   * @param mcpServersJson the MCP servers JSON to add.
    */
   public void addMcpServers(String mcpServersJson) {
     String mcpServers = parseMcpServers(mcpServersJson);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CurrentEditorContext.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/CurrentEditorContext.java
@@ -20,6 +20,8 @@ public class CurrentEditorContext {
 
   /**
    * Creates a new ConversationContextResult.
+   *
+   * @param uri the URI of the current editor document.
    */
   public CurrentEditorContext(String uri) {
     this.uri = uri;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/DidChangeFeatureFlagsParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/DidChangeFeatureFlagsParams.java
@@ -52,6 +52,8 @@ public class DidChangeFeatureFlagsParams {
 
   /**
    * Checks if the MCP is enabled.
+   *
+   * @return whether MCP is enabled.
    */
   public boolean isMcpEnabled() {
     boolean disabled = featureFlags != null && "0".equals(featureFlags.get("mcp"));
@@ -60,6 +62,8 @@ public class DidChangeFeatureFlagsParams {
 
   /**
    * Checks if the agent mode is enabled.
+   *
+   * @return whether agent mode is enabled.
    */
   public boolean isAgentModeEnabled() {
     // Agent mode is by default enabled.
@@ -70,6 +74,8 @@ public class DidChangeFeatureFlagsParams {
 
   /**
    * Checks if client preview features are enabled.
+   *
+   * @return whether client preview features are enabled.
    */
   public boolean isClientPreviewFeaturesEnabled() {
     boolean disabled = featureFlags != null && "0".equals(featureFlags.get("editor_preview_features"));
@@ -79,6 +85,8 @@ public class DidChangeFeatureFlagsParams {
   /**
    * Checks if the auto-approval feature is enabled.
    * Disabled only when the feature flag "agent_mode_auto_approval" is set to "0".
+   *
+   * @return whether the auto-approval feature is enabled.
    */
   public boolean isAutoApprovalEnabled() {
     boolean disabled = featureFlags != null && "0".equals(featureFlags.get("agent_mode_auto_approval"));

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/FileStat.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/FileStat.java
@@ -16,6 +16,8 @@ public class FileStat {
 
   /**
    * Gets the file size in bytes.
+   *
+   * @return the file size in bytes.
    */
   public long getSize() {
     return size;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/InitializationOptions.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/InitializationOptions.java
@@ -24,6 +24,9 @@ public class InitializationOptions {
 
   /**
    * Creates a new InitializationOptions.
+   *
+   * @param editorInfo the editor name and version.
+   * @param editorPluginInfo the editor plugin name and version.
    */
   public InitializationOptions(NameAndVersion editorInfo, NameAndVersion editorPluginInfo) {
     this.editorInfo = editorInfo;
@@ -32,6 +35,10 @@ public class InitializationOptions {
 
   /**
    * Creates a new InitializationOptions.
+   *
+   * @param editorInfo the editor name and version.
+   * @param editorPluginInfo the editor plugin name and version.
+   * @param copilotCapabilities the Copilot capabilities supported by the client.
    */
   public InitializationOptions(NameAndVersion editorInfo, NameAndVersion editorPluginInfo,
       CopilotCapabilities copilotCapabilities) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/InputSchemaPropertyValue.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/InputSchemaPropertyValue.java
@@ -17,6 +17,8 @@ public class InputSchemaPropertyValue {
 
   /**
    * Constructor for InputSchemaPropertyValue.
+   *
+   * @param type the schema property type.
    */
   public InputSchemaPropertyValue(String type) {
     this(type, "");
@@ -24,6 +26,9 @@ public class InputSchemaPropertyValue {
 
   /**
    * Constructor for InputSchemaPropertyValue.
+   *
+   * @param type the schema property type.
+   * @param description the schema property description.
    */
   public InputSchemaPropertyValue(String type, String description) {
     this.type = type;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/LanguageModelToolConfirmationResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/LanguageModelToolConfirmationResult.java
@@ -15,6 +15,8 @@ public class LanguageModelToolConfirmationResult {
 
   /**
    * Construct a new LanguageModelToolConfirmationResult by ToolConfirmationResult.
+   *
+   * @param result the tool confirmation result.
    */
   public LanguageModelToolConfirmationResult(ToolConfirmationResult result) {
     this.result = result.toString();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/LanguageModelToolResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/LanguageModelToolResult.java
@@ -34,6 +34,9 @@ public class LanguageModelToolResult {
 
   /**
    * Creates a new LanguageModelToolResult with content and ToolInvocationStatus.
+   *
+   * @param resultContent the text content returned by the tool invocation.
+   * @param status the status of the tool invocation.
    */
   public LanguageModelToolResult(String resultContent, ToolInvocationStatus status) {
     this.status = status.toString();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NextEditSuggestionsParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NextEditSuggestionsParams.java
@@ -28,6 +28,9 @@ public class NextEditSuggestionsParams {
 
   /**
    * Constructor with fields.
+   *
+   * @param textDocument the versioned text document for next edit suggestions.
+   * @param position the cursor position for next edit suggestions.
    */
   public NextEditSuggestionsParams(VersionedTextDocumentIdentifier textDocument, Position position) {
     this.textDocument = textDocument;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NextEditSuggestionsResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NextEditSuggestionsResult.java
@@ -88,7 +88,11 @@ public class NextEditSuggestionsResult {
       this.command = command;
     }
 
-    /** Convenience for future use (may return null). */
+    /**
+     * Convenience for future use (may return null).
+     *
+     * @return the UUID argument from the command, or {@code null} if unavailable.
+     */
     public String getUuid() {
       if (command == null || command.getArguments() == null || command.getArguments().isEmpty()) {
         return null;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyAcceptedParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyAcceptedParams.java
@@ -20,6 +20,8 @@ public class NotifyAcceptedParams {
 
   /**
    * Create a new NotifyAcceptedParams.
+   *
+   * @param uuid the unique identifier of the accepted completion.
    */
   public NotifyAcceptedParams(String uuid) {
     super();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyCodeAcceptanceParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyCodeAcceptanceParams.java
@@ -25,6 +25,10 @@ public class NotifyCodeAcceptanceParams {
 
   /**
    * Constructor.
+   *
+   * @param turnId the identifier of the turn containing the accepted code.
+   * @param acceptedFileCount the number of files accepted by the user.
+   * @param totalFileCount the initial number of files pending decision in this turn.
    */
   public NotifyCodeAcceptanceParams(String turnId, int acceptedFileCount, int totalFileCount) {
     this.turnId = turnId;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyRejectedParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyRejectedParams.java
@@ -19,6 +19,8 @@ public class NotifyRejectedParams {
 
   /**
    * Create a new NotifyRejectedParams.
+   *
+   * @param uuids the unique identifiers of the rejected completions.
    */
   public NotifyRejectedParams(List<String> uuids) {
     this.uuids = uuids;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyShownParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/NotifyShownParams.java
@@ -18,6 +18,8 @@ public class NotifyShownParams {
 
   /**
    * Creates a new NotifyShownParams.
+   *
+   * @param uuid the unique identifier of the shown completion.
    */
   public NotifyShownParams(String uuid) {
     this.uuid = uuid;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ProgressParamsAdapter.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ProgressParamsAdapter.java
@@ -26,6 +26,8 @@ public class ProgressParamsAdapter extends TypeAdapter<ProgressParams> {
 
   /**
    * Constructor.
+   *
+   * @param gson the Gson instance used to serialize and deserialize progress parameters.
    */
   public ProgressParamsAdapter(Gson gson) {
     this.gson = gson;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ReadDirectoryResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ReadDirectoryResult.java
@@ -90,6 +90,8 @@ public class ReadDirectoryResult {
 
     /**
      * Gets the entry name.
+     *
+     * @return the entry name.
      */
     public String getName() {
       return name;
@@ -101,6 +103,8 @@ public class ReadDirectoryResult {
 
     /**
      * Gets the file type.
+     *
+     * @return the file type.
      */
     public int getType() {
       return type;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/SignInConfirmParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/SignInConfirmParams.java
@@ -17,6 +17,8 @@ public class SignInConfirmParams {
 
   /**
    * Create a new parameter for SignInConfirm request.
+   *
+   * @param userCode the user code to confirm during sign-in.
    */
   public SignInConfirmParams(String userCode) {
     this.userCode = userCode;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ToolSpecificData.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/ToolSpecificData.java
@@ -49,6 +49,8 @@ public class ToolSpecificData {
   /**
    * Convenience accessor for todo list data when kind == "todoList".
    * Converts the raw data (LinkedTreeMap from Gson) to List of TodoItem.
+   *
+   * @return the todo list items, or {@code null} when the data is not a todo list.
    */
   public List<TodoItem> getTodoList() {
     if (!"todoList".equals(kind) || data == null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/Turn.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/Turn.java
@@ -22,6 +22,10 @@ public class Turn {
 
   /**
    * Creates a new Turn.
+   *
+   * @param request the request content for the turn.
+   * @param response the response text for the turn.
+   * @param agentSlug the slug of the agent that handled the turn.
    */
   public Turn(@NonNull Either<String, List<ChatCompletionContentPart>> request, String response, String agentSlug) {
     this.request = request;
@@ -31,6 +35,11 @@ public class Turn {
 
   /**
    * Creates a new Turn with turnId.
+   *
+   * @param request the request content for the turn.
+   * @param response the response text for the turn.
+   * @param agentSlug the slug of the agent that handled the turn.
+   * @param turnId the identifier of the turn.
    */
   public Turn(@NonNull Either<String, List<ChatCompletionContentPart>> request, String response, String agentSlug,
       String turnId) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/byok/ByokListModelParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/byok/ByokListModelParams.java
@@ -17,6 +17,9 @@ public class ByokListModelParams {
 
   /**
    * Default constructor.
+   *
+   * @param providerName the name of the BYOK model provider.
+   * @param enableFetchUrl whether the fetch URL should be enabled.
    */
   public ByokListModelParams(String providerName, Boolean enableFetchUrl) {
     this.providerName = providerName;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/byok/ByokModelProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/byok/ByokModelProvider.java
@@ -29,6 +29,9 @@ public enum ByokModelProvider {
   /**
    * Utility to check if a provider display name corresponds to AZURE.
    * This avoids scattering direct enum displayName comparisons across UI code.
+   *
+   * @param providerDisplayName the provider display name to check.
+   * @return whether the provider display name corresponds to Azure.
    */
   public static boolean isAzure(String providerDisplayName) {
     return AZURE.getDisplayName().equals(providerDisplayName);

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/git/GenerateCommitMessageParams.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/git/GenerateCommitMessageParams.java
@@ -29,6 +29,10 @@ public class GenerateCommitMessageParams {
 
   /**
    * Creates a new GenerateCommitMessageParams.
+   *
+   * @param changes the changes to summarize in the commit message.
+   * @param userCommits the user's previous commit messages.
+   * @param recentCommits recent commit messages from the repository.
    */
   public GenerateCommitMessageParams(List<String> changes, List<String> userCommits, List<String> recentCommits) {
     super();

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/git/GenerateCommitMessageResult.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/lsp/protocol/git/GenerateCommitMessageResult.java
@@ -16,6 +16,8 @@ public class GenerateCommitMessageResult {
 
   /**
    * Creates a new GenerateCommitMessageResult.
+   *
+   * @param commitMessage the generated commit message.
    */
   public GenerateCommitMessageResult(String commitMessage) {
     this.commitMessage = commitMessage;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/nes/NextEditSuggestionProvider.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/nes/NextEditSuggestionProvider.java
@@ -32,6 +32,8 @@ public class NextEditSuggestionProvider {
 
   /**
    * Construct a NextEditSuggestionProvider.
+   *
+   * @param ls the language server connection used to fetch next edit suggestions.
    */
   public NextEditSuggestionProvider(CopilotLanguageServerConnection ls) {
     this.lsConnection = ls;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationDataFactory.java
@@ -51,6 +51,9 @@ public class ConversationDataFactory {
 
   /**
    * Creates a new ConversationData from initial parameters.
+   *
+   * @param conversationId the ID for the new conversation.
+   * @return the newly created conversation data.
    */
   public ConversationData createConversationData(String conversationId) {
     ConversationData conversationData = new ConversationData();
@@ -64,6 +67,14 @@ public class ConversationDataFactory {
 
   /**
    * Creates a user turn from a message.
+   *
+   * @param conversationId the ID of the conversation containing the turn.
+   * @param turnId the ID of the user turn.
+   * @param message the message text for the user turn.
+   * @param model the model used for the user turn.
+   * @param chatMode the chat mode used for the user turn.
+   * @param customChatModeId the custom chat mode ID, if applicable.
+   * @return the newly created user turn data.
    */
   public UserTurnData createUserTurnData(String conversationId, String turnId, String message, String model,
       String chatMode, String customChatModeId) {
@@ -85,6 +96,9 @@ public class ConversationDataFactory {
 
   /**
    * Creates a copilot turn data for assistant responses.
+   *
+   * @param turnId the ID of the Copilot turn.
+   * @return the newly created Copilot turn data.
    */
   public CopilotTurnData createCopilotTurnData(String turnId) {
     CopilotTurnData copilotTurn = new CopilotTurnData();
@@ -203,6 +217,9 @@ public class ConversationDataFactory {
 
   /**
    * Updates basic conversation metadata from progress (pure transformation).
+   *
+   * @param conversationData the conversation data to update.
+   * @param progress the progress value containing metadata updates.
    */
   public void updateConversationMetadata(ConversationData conversationData, ChatProgressValue progress) {
     if (StringUtils.isNotBlank(progress.getSuggestedTitle())) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationPersistenceManager.java
@@ -58,6 +58,9 @@ public class ConversationPersistenceManager {
 
   /**
    * Loads a full conversation by ID.
+   *
+   * @param conversationId the ID of the conversation to load.
+   * @return a future containing the loaded conversation data.
    */
   public CompletableFuture<ConversationData> loadConversation(String conversationId) {
     return CompletableFuture.supplyAsync(() -> {
@@ -113,6 +116,7 @@ public class ConversationPersistenceManager {
    *
    * @param newConversationId the new conversation ID to assign
    * @param historyConversationId the ID of the history record to update
+   * @return a future that completes when the history record has been updated.
    */
   public CompletableFuture<Void> updateConversationIdToHistoryRecord(String newConversationId,
       String historyConversationId) {
@@ -160,6 +164,9 @@ public class ConversationPersistenceManager {
    * @param model the model used for this turn
    * @param chatMode the chat mode for this turn
    * @param customChatModeId the custom chat mode ID (if applicable)
+   * @param currentFile the current file referenced by the user turn.
+   * @param references the additional resources referenced by the user turn.
+   * @return a future containing the updated conversation data.
    */
   public CompletableFuture<ConversationData> persistUserTurnInfo(String conversationId, String turnId, String message,
       CopilotModel model, String chatMode, String customChatModeId, IFile currentFile, List<IResource> references) {
@@ -211,6 +218,7 @@ public class ConversationPersistenceManager {
    * @param conversationId the conversation ID
    * @param progress the progress value
    * @param thinkingBlockId the UI-generated thinking block ID, when the progress belongs to a thinking round
+   * @return a future that completes when the conversation progress has been cached.
    */
   public CompletableFuture<Void> cacheConversationProgress(String conversationId, ChatProgressValue progress,
       String thinkingBlockId) {
@@ -234,6 +242,7 @@ public class ConversationPersistenceManager {
    * @param conversationId the conversation ID
    * @param progress the progress value
    * @param thinkingBlockId the UI-generated thinking block ID, when the progress belongs to a thinking round
+   * @return a future that completes when the conversation progress has been persisted.
    */
   public CompletableFuture<Void> persistConversationProgress(String conversationId, ChatProgressValue progress,
       String thinkingBlockId) {
@@ -255,6 +264,9 @@ public class ConversationPersistenceManager {
 
   /**
    * Persists a cached conversation to disk if it exists in the cache.
+   *
+   * @param conversationId the ID of the cached conversation to persist.
+   * @return a future that completes when the cached conversation has been persisted.
    */
   public CompletableFuture<Void> persistCachedConversation(String conversationId) {
     return CompletableFuture.runAsync(() -> {
@@ -309,6 +321,10 @@ public class ConversationPersistenceManager {
 
   /**
    * Updates a conversation with progress data. This method is synchronous and handles all IO operations internally.
+   *
+   * @param conversationId the ID of the conversation to update.
+   * @param progress the progress value to apply.
+   * @return a future containing the updated conversation data.
    */
   public CompletableFuture<ConversationData> updateConversationProgress(String conversationId,
       ChatProgressValue progress) {
@@ -360,6 +376,7 @@ public class ConversationPersistenceManager {
    * @param turnId the turn ID
    * @param thinkingBlockId the thinking block ID
    * @param title the generated title
+   * @return a future that completes when the thinking block title has been updated.
    */
   public CompletableFuture<Void> updateThinkingBlockTitle(String conversationId, String turnId, String thinkingBlockId,
       String title) {
@@ -385,6 +402,7 @@ public class ConversationPersistenceManager {
    * @param conversationId the conversation ID
    * @param turnId the turn ID
    * @param thinkingBlockId the thinking block ID
+   * @return a future that completes when the thinking block has been cancelled.
    */
   public CompletableFuture<Void> cancelThinkingBlock(String conversationId, String turnId, String thinkingBlockId) {
     if (StringUtils.isAnyBlank(conversationId, turnId, thinkingBlockId)) {
@@ -561,6 +579,7 @@ public class ConversationPersistenceManager {
    * Removes a conversation by ID from both disk and in-memory cache.
    *
    * @param conversationId the ID of the conversation to remove
+   * @return a future that completes when the conversation has been removed.
    */
   public CompletableFuture<Void> removeConversationById(String conversationId) {
     return CompletableFuture.runAsync(() -> {
@@ -581,6 +600,7 @@ public class ConversationPersistenceManager {
    *
    * @param conversationId the ID of the conversation to update
    * @param newTitle the new title to set
+   * @return a future that completes when the conversation title has been updated.
    */
   public CompletableFuture<Void> updateConversationTitle(String conversationId, String newTitle) {
     return CompletableFuture.runAsync(() -> {
@@ -604,6 +624,7 @@ public class ConversationPersistenceManager {
    *
    * @param conversationId the ID of the conversation to update
    * @param todos the list of todo items to save
+   * @return a future that completes when the todo list has been updated.
    */
   public CompletableFuture<Void> updateTodoList(String conversationId, List<TodoItem> todos) {
     return CompletableFuture.runAsync(() -> {
@@ -627,6 +648,7 @@ public class ConversationPersistenceManager {
    *
    * @param params the coding agent message request parameters
    * @param agentSlug the slug identifier of the coding agent
+   * @return a future that completes when the coding agent message has been added.
    */
   public CompletableFuture<Void> addCodingAgentMessage(CodingAgentMessageRequestParams params, String agentSlug) {
     return CompletableFuture.runAsync(() -> {
@@ -667,6 +689,7 @@ public class ConversationPersistenceManager {
    * @param billingMultiplier the billing multiplier for the model
    * @param reasoningEffort the reasoning effort sent for this turn, or {@code null} when the model does not support
    *     reasoning effort
+   * @return a future that completes when the model information has been persisted.
    */
   public CompletableFuture<Void> persistModelInfo(String conversationId, String turnId, String modelName,
       double billingMultiplier, String reasoningEffort) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationXmlData.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/ConversationXmlData.java
@@ -20,6 +20,11 @@ public class ConversationXmlData {
 
   /**
    * Default constructor initializing default values.
+   *
+   * @param conversationId the conversation ID.
+   * @param title the conversation title.
+   * @param creationDate the conversation creation date.
+   * @param lastMessageDate the date of the last message.
    */
   public ConversationXmlData(String conversationId, String title, Instant creationDate, Instant lastMessageDate) {
     this.conversationId = conversationId;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/CopilotTurnData.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/CopilotTurnData.java
@@ -475,6 +475,8 @@ public class CopilotTurnData extends AbstractTurnData {
     /**
      * The BYOK model provider responsible for the error, or {@code null} when the failing model was a
      * built-in Copilot model.
+     *
+     * @return the BYOK model provider name, or {@code null} for built-in Copilot models.
      */
     public String getModelProviderName() {
       return modelProviderName;
@@ -804,7 +806,12 @@ public class CopilotTurnData extends AbstractTurnData {
     public ThinkingBlockData() {
     }
 
-    /** Construct with id and content. */
+    /**
+     * Construct with id and content.
+     *
+     * @param id the thinking block ID.
+     * @param content the thinking block content.
+     */
     public ThinkingBlockData(String id, String content) {
       this.id = id;
       this.content = content;

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/UserTurnData.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/persistence/UserTurnData.java
@@ -56,6 +56,8 @@ public class UserTurnData extends AbstractTurnData {
 
   /**
    * Set the current document as a TextDocument instance created from the provided IResource.
+   *
+   * @param resource the resource to convert into the current document.
    */
   public void setCurrentDocument(IResource resource) {
     if (resource != null) {
@@ -69,6 +71,8 @@ public class UserTurnData extends AbstractTurnData {
 
   /**
    * Set the list of IResources as the references after converting them to TextDocument instances.
+   *
+   * @param refs the resources to convert into reference documents.
    */
   public void setReferences(List<IResource> refs) {
     if (refs != null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/AnonymizeUtils.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/AnonymizeUtils.java
@@ -71,6 +71,9 @@ public class AnonymizeUtils {
 
   /**
    * Remove PII data from the given properties.
+   *
+   * @param value the text value to anonymize.
+   * @return the anonymized text value.
    */
   public static String removePii(final String value) {
     if (StringUtils.isBlank(value)) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/FileUtils.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/FileUtils.java
@@ -131,6 +131,9 @@ public class FileUtils {
 
   /**
    * Returns true if the file needs to be excluded from the referenced files.
+   *
+   * @param file the file to check.
+   * @return true if the file should be excluded from referenced files.
    */
   public static boolean isExcludedFromReferencedFiles(@Nullable IFile file) {
     if (file == null) {
@@ -145,6 +148,9 @@ public class FileUtils {
 
   /**
    * Returns true if the file needs to be excluded from 'Current file' reference in chat.
+   *
+   * @param file the file to check.
+   * @return true if the file should be excluded from the current file reference.
    */
   public static boolean isExcludedFromCurrentFile(@Nullable IFile file) {
     if (file == null) {

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/PlatformUtils.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/PlatformUtils.java
@@ -60,6 +60,8 @@ public class PlatformUtils {
 
   /**
    * Get the version of the Copilot plugin.
+   *
+   * @return the Copilot plugin version, or {@code "unknown"} if unavailable.
    */
   public static String getBundleVersion() {
     Bundle bundle = CopilotCore.getPlugin().getBundle();
@@ -68,6 +70,8 @@ public class PlatformUtils {
 
   /**
    * Check if the Copilot plugin is a nightly build.
+   *
+   * @return true if the Copilot plugin version is a nightly build.
    */
   public static boolean isNightly() {
     return getBundleVersion().toString().endsWith("_nightly");
@@ -151,6 +155,8 @@ public class PlatformUtils {
   /**
    * Returns the transcript directory for CLS session persistence, following the same convention as the IntelliJ
    * Copilot plugin ({@code ~/.copilot/eclipse}).
+   *
+   * @return the absolute path to the transcript directory.
    */
   public static String getTranscriptDirectory() {
     String userHome = System.getProperty("user.home");

--- a/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/WorkspaceUtils.java
+++ b/com.microsoft.copilot.eclipse.core/src/com/microsoft/copilot/eclipse/core/utils/WorkspaceUtils.java
@@ -83,6 +83,8 @@ public class WorkspaceUtils {
 
   /**
    * List all top level projects as workspace folders in the current workspace.
+   *
+   * @return list of workspace folders for all top-level projects.
    */
   public static List<WorkspaceFolder> listWorkspaceFolders() {
     List<IProject> projects = WorkspaceUtils.listTopLevelProjects();

--- a/com.microsoft.copilot.eclipse.terminal.api/src/com/microsoft/copilot/eclipse/terminal/api/TerminalServiceManager.java
+++ b/com.microsoft.copilot.eclipse.terminal.api/src/com/microsoft/copilot/eclipse/terminal/api/TerminalServiceManager.java
@@ -108,6 +108,8 @@ public class TerminalServiceManager {
 
   /**
    * Get the singleton instance of TerminalServiceManager.
+   *
+   * @return the singleton {@link TerminalServiceManager} instance.
    */
   public static TerminalServiceManager getInstance() {
     return InstanceHolder.INSTANCE;
@@ -115,6 +117,8 @@ public class TerminalServiceManager {
 
   /**
    * Add a listener for terminal service events.
+   *
+   * @param listener the terminal service listener to register.
    */
   public void addListener(TerminalServiceListener listener) {
     if (listener != null) {
@@ -135,6 +139,8 @@ public class TerminalServiceManager {
 
   /**
    * Remove a listener for terminal service events.
+   *
+   * @param listener the terminal service listener to unregister.
    */
   public void removeListener(TerminalServiceListener listener) {
     listeners.remove(listener);
@@ -142,6 +148,8 @@ public class TerminalServiceManager {
 
   /**
    * Get the current terminal service if available.
+   *
+   * @return the current {@link IRunInTerminalTool} service, or {@code null} if none is available.
    */
   public IRunInTerminalTool getCurrentService() {
     return currentService;

--- a/com.microsoft.copilot.eclipse.ui.jobs/src/com/microsoft/copilot/eclipse/ui/jobs/views/JobsView.java
+++ b/com.microsoft.copilot.eclipse.ui.jobs/src/com/microsoft/copilot/eclipse/ui/jobs/views/JobsView.java
@@ -77,6 +77,8 @@ public class JobsView {
 
   /**
    * Create the view part control.
+   *
+   * @param parent the parent composite in which the view's controls are created.
    */
   @PostConstruct
   public void createPartControl(Composite parent) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/CopilotUi.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/CopilotUi.java
@@ -191,6 +191,8 @@ public class CopilotUi extends AbstractUIPlugin {
   /**
    * Reads the boolean preference from all scopes.
    *
+   * @param key the preference key to read.
+   * @param defaultValue the value to return when the preference is not set.
    * @return preference value considering all scopes (config, instance and product)
    */
   public static boolean getBooleanPreference(String key, boolean defaultValue) {
@@ -201,6 +203,8 @@ public class CopilotUi extends AbstractUIPlugin {
   /**
    * Reads the int preference from all scopes.
    *
+   * @param key the preference key to read.
+   * @param defaultValue the value to return when the preference is not set.
    * @return preference value considering all scopes (config, instance and product)
    */
   public static int getIntPreference(String key, int defaultValue) {
@@ -211,6 +215,8 @@ public class CopilotUi extends AbstractUIPlugin {
   /**
    * Read the String preference from all scopes.
    *
+   * @param key the preference key to read.
+   * @param defaultValue the value to return when the preference is not set.
    * @return preference value considering all scopes (config, instance and product)
    */
   public static String getStringPreference(String key, String defaultValue) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ActionBar.java
@@ -134,6 +134,10 @@ public class ActionBar extends Composite implements NewConversationListener {
 
   /**
    * Creates a new InputArea.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   * @param chatServiceManager the chat service manager for the action bar.
    */
   public ActionBar(Composite parent, int style, ChatServiceManager chatServiceManager) {
     super(parent, SWT.NONE);
@@ -847,6 +851,8 @@ public class ActionBar extends Composite implements NewConversationListener {
   /**
    * Returns the current action bar conversation state. Return true if the conversation is stand by or cancelled, false
    * otherwise
+   *
+   * @return {@code true} when the action bar is in send-button state; {@code false} otherwise.
    */
   public boolean isSendButton() {
     return isSendButton;
@@ -1013,6 +1019,8 @@ public class ActionBar extends Composite implements NewConversationListener {
   /**
    * Returns the input-area wrapper that owns {@code TodoListBar}, {@code WorkingSetBar}, and the bordered chat input.
    * Services creating those top bars should parent them here so the sibling {@code StaticBanner} stays above.
+   *
+   * @return the input-area composite.
    */
   public Composite getInputArea() {
     return this.inputArea;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AddContextButton.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AddContextButton.java
@@ -42,6 +42,8 @@ public class AddContextButton extends Composite {
 
   /**
    * Creates a new AddContextButton.
+   *
+   * @param parent the parent composite.
    */
   public AddContextButton(Composite parent) {
     super(parent, SWT.NONE);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentStatusLabel.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentStatusLabel.java
@@ -125,6 +125,8 @@ public class AgentStatusLabel extends Composite {
 
   /**
    * Set the text to display next to the icon.
+   *
+   * @param text the text to display next to the status icon.
    */
   public void setText(String text) {
     if (this.textLabel == null) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentToolCancelLabel.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/AgentToolCancelLabel.java
@@ -24,6 +24,7 @@ public class AgentToolCancelLabel extends Composite {
    *
    * @param parent the parent composite
    * @param style the style
+   * @param cancelMessage the cancellation message to display.
    */
   public AgentToolCancelLabel(Composite parent, int style, String cancelMessage) {
     super(parent, style);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/BaseTurnWidget.java
@@ -74,7 +74,11 @@ public abstract class BaseTurnWidget extends Composite {
   protected Font boldFont = null;
   protected InvokeToolConfirmationDialog confirmDialog;
 
-  /** Returns the current confirmation dialog, or {@code null} if none active. */
+  /**
+   * Returns the current confirmation dialog, or {@code null} if none active.
+   *
+   * @return the current confirmation dialog, or {@code null} if none is active.
+   */
   public InvokeToolConfirmationDialog getConfirmDialog() {
     return confirmDialog;
   }
@@ -658,6 +662,7 @@ public abstract class BaseTurnWidget extends Composite {
    *
    * @param content The confirmation content with title, message, and action buttons.
    * @param input The input object to be passed to the tool.
+   * @return a future completed with the user's tool confirmation result.
    */
   public CompletableFuture<LanguageModelToolConfirmationResult> requestToolExecutionConfirmation(
       ConfirmationContent content, Object input) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatContentViewer.java
@@ -107,6 +107,7 @@ public class ChatContentViewer extends Composite {
    *
    * @param parent the parent composite
    * @param style the style
+   * @param serviceManager the chat service manager used by the viewer.
    */
   public ChatContentViewer(Composite parent, int style, ChatServiceManager serviceManager) {
     super(parent, style | SWT.V_SCROLL | SWT.DOUBLE_BUFFERED);
@@ -159,6 +160,9 @@ public class ChatContentViewer extends Composite {
 
   /**
    * Should be called when user sends a message.
+   *
+   * @param workDoneToken the work-done token identifying the turn.
+   * @param message the user message to start the turn with.
    */
   public void startNewTurn(String workDoneToken, String message) {
     BaseTurnWidget turnWidget = getLatestOrCreateNewTurnWidget(workDoneToken, false, true);
@@ -174,6 +178,11 @@ public class ChatContentViewer extends Composite {
 
   /**
    * Create a new turn.
+   *
+   * @param workDoneToken the work-done token identifying the turn.
+   * @param isCopilot whether the turn is for Copilot output.
+   * @param forceCreateNewTurn whether to create a new turn even if the latest turn could be reused.
+   * @return the latest turn widget or a newly created turn widget.
    */
   public BaseTurnWidget getLatestOrCreateNewTurnWidget(String workDoneToken, boolean isCopilot,
       boolean forceCreateNewTurn) {
@@ -210,7 +219,11 @@ public class ChatContentViewer extends Composite {
 
   }
 
-  /** Set the conversation ID used for thinking-block persistence. */
+  /**
+   * Set the conversation ID used for thinking-block persistence.
+   *
+   * @param conversationId the conversation ID to use for persistence.
+   */
   public void setConversationId(String conversationId) {
     this.conversationId = conversationId;
   }
@@ -218,6 +231,8 @@ public class ChatContentViewer extends Composite {
   /**
    * Process turn event. Events are queued and drained in batches on the UI thread so the LSP thread
    * is never blocked and multiple in-flight events coalesce into a single layout pass.
+   *
+   * @param value the chat progress event to process.
    */
   public void processTurnEvent(ChatProgressValue value) {
     pendingEvents.offer(value);
@@ -352,7 +367,12 @@ public class ChatContentViewer extends Composite {
     }
   }
 
-  /** Returns the active thinking block ID last observed while processing this turn's progress. */
+  /**
+   * Returns the active thinking block ID last observed while processing this turn's progress.
+   *
+   * @param turnId the turn ID whose active thinking block is requested.
+   * @return the active thinking block ID, or {@code null} if none is tracked for the turn.
+   */
   public String getActiveThinkingBlockId(String turnId) {
     return activeThinkingBlockIds.get(turnId);
   }
@@ -368,6 +388,8 @@ public class ChatContentViewer extends Composite {
 
   /**
    * Append message to the latest turn.
+   *
+   * @param message the message text to append.
    */
   public void appendMessageToTheLatestTurn(String message) {
     if (this.latestTurnWidget != null) {
@@ -462,6 +484,9 @@ public class ChatContentViewer extends Composite {
 
   /**
    * Get an existed turn widget by turn ID.
+   *
+   * @param turnId the turn ID to look up.
+   * @return the turn widget for the given ID, or {@code null} if it does not exist.
    */
   public BaseTurnWidget getTurnWidget(String turnId) {
     return turns.get(turnId);
@@ -483,6 +508,8 @@ public class ChatContentViewer extends Composite {
 
   /**
    * Render error message banner on the chat content viewer.
+   *
+   * @param errorMessage the error message to render.
    */
   public void renderErrorMessage(String errorMessage) {
     if (this.errorWidget != null) {
@@ -793,6 +820,8 @@ public class ChatContentViewer extends Composite {
    * the turn's {@link #topOf} value with the local y offsets down to {@code target}, then
    * adjusts {@link #scrollOffset} by the minimum amount needed to bring {@code target} fully
    * into the viewport.</p>
+   *
+   * @param target the composite to make visible.
    */
   public void showControl(Composite target) {
     if (target == null || target.isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ChatView.java
@@ -1459,6 +1459,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
   /**
    * Get the current conversation ID.
+   *
+   * @return the current conversation ID.
    */
   public String getConversationId() {
     return this.conversationId;
@@ -1466,6 +1468,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
   /**
    * Get the current subagent conversation ID, or null if not in a subagent context.
+   *
+   * @return the current subagent conversation ID, or {@code null} if not in a subagent context.
    */
   public String getSubagentConversationId() {
     return this.subagentConversationId;
@@ -1473,6 +1477,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
   /**
    * Get the current chat content viewer.
+   *
+   * @return the current chat content viewer.
    */
   public ChatContentViewer getChatContentViewer() {
     return this.chatContentViewer;
@@ -1480,6 +1486,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
   /**
    * Get the content section of the chat view.
+   *
+   * @return the content wrapper composite.
    */
   public Composite getContentWrapper() {
     return this.contentWrapper;
@@ -1491,6 +1499,8 @@ public class ChatView extends ViewPart implements ChatProgressListener, MessageL
 
   /**
    * Register a new conversation listener to the action bar.
+   *
+   * @param listener the new conversation listener to register.
    */
   public void registerNewConversationListenerToTheTopBanner(NewConversationListener listener) {
     this.topBanner.registerNewConversationListener(listener);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CopilotTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CopilotTurnWidget.java
@@ -32,6 +32,11 @@ public class CopilotTurnWidget extends ThinkingTurnWidget {
 
   /**
    * Create the widget.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   * @param serviceManager the chat service manager used by the widget.
+   * @param turnId the turn ID associated with the widget.
    */
   public CopilotTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId) {
     super(parent, style, serviceManager, turnId, null);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CurrentReferencedFile.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/CurrentReferencedFile.java
@@ -32,6 +32,8 @@ public class CurrentReferencedFile extends ReferencedFile {
 
   /**
    * Creates a new CurrentReferencedFile.
+   *
+   * @param parent the parent composite.
    */
   public CurrentReferencedFile(Composite parent) {
     // No need to get supportVision here, as currentFile will not be an image file.
@@ -74,6 +76,8 @@ public class CurrentReferencedFile extends ReferencedFile {
 
   /**
    * update the visible icon.
+   *
+   * @param isCurrentFileVisible whether the current file is visible in the chat context.
    */
   public void updateCloseClickBtnIcon(boolean isCurrentFileVisible) {
     if (isCurrentFileVisible) {
@@ -96,6 +100,8 @@ public class CurrentReferencedFile extends ReferencedFile {
 
   /**
    * Set the current selection to display.
+   *
+   * @param selection the current editor selection to display, or {@code null} to clear it.
    */
   public void setSelection(@Nullable Range selection) {
     this.currentSelection = selection;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/DragReferenceManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/DragReferenceManager.java
@@ -34,13 +34,18 @@ public class DragReferenceManager {
    * Create a new DragReferenceManager.
    *
    * @param chatView the chat view
+   * @param referencedFileService the service used to manage referenced files.
    */
   public DragReferenceManager(ChatView chatView, ReferencedFileService referencedFileService) {
     this.chatView = chatView;
     this.referencedFileService = referencedFileService;
   }
 
-  /** Attach DnD to a composite. Re-attach will dispose the previous target. */
+  /**
+   * Attach DnD to a composite. Re-attach will dispose the previous target.
+   *
+   * @param parent the composite to attach drag-and-drop support to.
+   */
   public void attach(Composite parent) {
     if (parent == null || parent.isDisposed()) {
       return;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ErrorWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ErrorWidget.java
@@ -23,6 +23,7 @@ public class ErrorWidget extends Composite {
    * Create the composite.
    *
    * @param parent the parent composite
+   * @param style the widget style.
    * @param message the message to display
    */
   public ErrorWidget(Composite parent, int style, String message) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/InvokeToolConfirmationDialog.java
@@ -90,6 +90,8 @@ public class InvokeToolConfirmationDialog extends Composite {
 
   /**
    * Returns the action the user selected, or {@code null} if dismissed.
+   *
+   * @return the selected confirmation action, or {@code null} if the dialog was dismissed.
    */
   public ConfirmationAction getSelectedAction() {
     return selectedAction;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ReferencedFile.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ReferencedFile.java
@@ -50,6 +50,10 @@ public class ReferencedFile extends Composite {
 
   /**
    * Creates a new TwinButton.
+   *
+   * @param parent the parent composite.
+   * @param file the referenced workspace resource.
+   * @param isUnSupportedFile whether the file is unsupported by the current model.
    */
   public ReferencedFile(Composite parent, IResource file, boolean isUnSupportedFile) {
     super(parent, SWT.BORDER);
@@ -127,6 +131,8 @@ public class ReferencedFile extends Composite {
 
   /**
    * Returns whether this file is unsupported by the current model.
+   *
+   * @return {@code true} if this file is unsupported by the current model; {@code false} otherwise.
    */
   public boolean isFileUnSupported() {
     return isUnSupportedFile;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/SourceViewerComposite.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/SourceViewerComposite.java
@@ -58,6 +58,13 @@ public class SourceViewerComposite extends Composite {
 
   /**
    * Constructs a new SourceViewerComposite.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   * @param serviceManager the chat service manager used by the source viewer.
+   * @param language the language of the source content.
+   * @param turnId the turn ID associated with the source content.
+   * @param codeBlockIndex the index of the code block within the turn.
    */
   public SourceViewerComposite(Composite parent, int style, ChatServiceManager serviceManager, String language,
       String turnId, int codeBlockIndex) {
@@ -71,6 +78,8 @@ public class SourceViewerComposite extends Composite {
 
   /**
    * Sets the text to be displayed in the source viewer.
+   *
+   * @param text the text to display in the source viewer.
    */
   public void setText(String text) {
     if (sourceViewer.getDocument() == null) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/SubagentTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/SubagentTurnWidget.java
@@ -24,6 +24,12 @@ public class SubagentTurnWidget extends ThinkingTurnWidget {
 
   /**
    * Create the widget.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   * @param serviceManager the chat service manager used by the widget.
+   * @param turnId the parent turn ID associated with the subagent widget.
+   * @param toolCall the subagent tool call that provides role information.
    */
   public SubagentTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId,
       AgentToolCall toolCall) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingBlock.java
@@ -75,7 +75,12 @@ public class ThinkingBlock extends Composite {
 
   private final IStylingEngine stylingEngine = PlatformUI.getWorkbench().getService(IStylingEngine.class);
 
-  /** Construct an empty thinking block; the spinner starts immediately. */
+  /**
+   * Construct an empty thinking block; the spinner starts immediately.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   */
   public ThinkingBlock(Composite parent, int style) {
     super(parent, style);
     GridLayout layout = new GridLayout(1, false);
@@ -94,7 +99,11 @@ public class ThinkingBlock extends Composite {
     updateChevron();
   }
 
-  /** Append a thinking stream fragment. Null/empty fragments are ignored. */
+  /**
+   * Append a thinking stream fragment. Null/empty fragments are ignored.
+   *
+   * @param fragment the thinking stream fragment to append.
+   */
   public void appendText(String fragment) {
     if (fragment == null || fragment.isEmpty()) {
       return;
@@ -122,6 +131,8 @@ public class ThinkingBlock extends Composite {
    * Cancel the thinking block. If still streaming, shows the cancel icon and collapses. If already sealed (thinking
    * content finished, title fetch in flight), simply finalizes as completed since thinking itself was not interrupted.
    * No-op if already finalized.
+   *
+   * @return {@code true} if the block was marked cancelled; {@code false} otherwise.
    */
   public boolean showCancelled() {
     if (isFinalized()) {
@@ -160,27 +171,47 @@ public class ThinkingBlock extends Composite {
     unwrapBodyFromScroller();
   }
 
-  /** True only while new thinking stream fragments should still be appended to this block. */
+  /**
+   * True only while new thinking stream fragments should still be appended to this block.
+   *
+   * @return {@code true} while this block accepts thinking stream fragments; {@code false} otherwise.
+   */
   public boolean isAcceptingThinkStream() {
     return state == State.STREAMING;
   }
 
-  /** True once the block has been completed or cancelled (spinner stopped, final title shown). */
+  /**
+   * True once the block has been completed or cancelled (spinner stopped, final title shown).
+   *
+   * @return {@code true} once this block has been completed or cancelled; {@code false} otherwise.
+   */
   public boolean isFinalized() {
     return state == State.COMPLETED || state == State.CANCELLED;
   }
 
-  /** The unique ID for this thinking block, shared with the persistence layer. */
+  /**
+   * The unique ID for this thinking block, shared with the persistence layer.
+   *
+   * @return the unique thinking block ID.
+   */
   public String getThinkingId() {
     return thinkingId;
   }
 
-  /** The full accumulated thinking text streamed so far. */
+  /**
+   * The full accumulated thinking text streamed so far.
+   *
+   * @return the full accumulated thinking text.
+   */
   public String getAccumulatedText() {
     return textBuffer.toString();
   }
 
-  /** Non-blank {@code **Title**} strings extracted from the accumulated thinking text. */
+  /**
+   * Non-blank {@code **Title**} strings extracted from the accumulated thinking text.
+   *
+   * @return the non-blank title strings extracted from the accumulated thinking text.
+   */
   public String[] getExtractedTitles() {
     // Reuse the already-parsed section list rather than re-scanning the buffer.
     return sections.stream()
@@ -395,7 +426,11 @@ public class ThinkingBlock extends Composite {
     return s.substring(0, end);
   }
 
-  /** Update the header title text. */
+  /**
+   * Update the header title text.
+   *
+   * @param text the title text to display.
+   */
   public void setTitle(String text) {
     if (titleLabel == null || titleLabel.isDisposed()) {
       return;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/ThinkingTurnWidget.java
@@ -44,6 +44,9 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
    * Set the conversation ID and server-assigned turn ID for thinking-block persistence.
    * Sets on both this widget and the current active widget (if different) so that
    * sealThinking/cancel work regardless of which widget is active at call time.
+   *
+   * @param conversationId the conversation ID for thinking-block persistence.
+   * @param persistTurnId the server-assigned turn ID for thinking-block persistence.
    */
   public void setConversationContext(String conversationId, String persistTurnId) {
     this.conversationId = conversationId;
@@ -58,6 +61,8 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
   /**
    * Append a thinking stream fragment from the language server, routing to the active turn (parent or subagent).
    * Must be called on the UI thread.
+   *
+   * @param thinking the thinking stream fragment to append.
    */
   public void appendThinking(Thinking thinking) {
     // Preserve whitespace-only thinking fragments; they can carry markdown boundaries between sections.
@@ -143,7 +148,11 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
         });
   }
 
-  /** Returns the active thinking block ID for persistence context, or {@code null} if none exists. */
+  /**
+   * Returns the active thinking block ID for persistence context, or {@code null} if none exists.
+   *
+   * @return the active thinking block ID, or {@code null} if none exists.
+   */
   public String getActiveThinkingBlockId() {
     ThinkingTurnWidget active = getActiveTurnWidget();
     if (active == null || active.isDisposed() || active.currentBlock == null || active.currentBlock.isDisposed()) {
@@ -192,6 +201,8 @@ public abstract class ThinkingTurnWidget extends BaseTurnWidget {
   /**
    * Restore a completed thinking block from persisted data. Creates a ThinkingBlock that is
    * already in the completed state with the given content and title.
+   *
+   * @param data the persisted thinking block data to restore.
    */
   public void restoreThinkingBlock(ThinkingBlockData data) {
     if (isDisposed() || data == null || StringUtils.isBlank(data.getContent())) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/TodoListBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/TodoListBar.java
@@ -54,7 +54,12 @@ public class TodoListBar extends Composite {
   private Image inProgressImage;
   private Image notStartedImage;
 
-  /** Constructor. */
+  /**
+   * Constructor.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   */
   public TodoListBar(Composite parent, int style) {
     super(parent, style | SWT.BORDER);
     this.todoListService = CopilotUi.getPlugin().getChatServiceManager().getTodoListService();
@@ -83,6 +88,8 @@ public class TodoListBar extends Composite {
 
   /**
    * Builds the todo list bar with the given todos.
+   *
+   * @param todos the todo items to display in the bar.
    */
   public void buildTodoListBar(List<TodoItem> todos) {
     if (todos == null || isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/UserTurnWidget.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/UserTurnWidget.java
@@ -31,6 +31,11 @@ public class UserTurnWidget extends BaseTurnWidget {
 
   /**
    * Create the widget.
+   *
+   * @param parent the parent composite.
+   * @param style the widget style.
+   * @param serviceManager the chat service manager used by the widget.
+   * @param turnId the turn ID associated with the widget.
    */
   public UserTurnWidget(Composite parent, int style, ChatServiceManager serviceManager, String turnId) {
     super(parent, style, serviceManager, turnId, false, null);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/WorkingSetBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/WorkingSetBar.java
@@ -388,6 +388,11 @@ public class WorkingSetBar extends Composite {
 
     /**
      * Constructs a new FileRow.
+     *
+     * @param parent the parent composite.
+     * @param style the widget style.
+     * @param fileImage the image representing the changed file.
+     * @param file the changed file represented by this row.
      */
     public FileRow(Composite parent, int style, Image fileImage, ChangedFile file) {
       super(parent, style);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/AttachedFileRegistry.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/AttachedFileRegistry.java
@@ -35,6 +35,8 @@ public class AttachedFileRegistry {
   /**
    * Stages file paths for auto-approve before the conversation ID is
    * known. These are checked by {@link #isAttachedFile} immediately.
+   *
+   * @param filePaths the file paths to stage for auto-approval.
    */
   public void addPending(Collection<String> filePaths) {
     if (filePaths == null || filePaths.isEmpty()) {
@@ -49,6 +51,8 @@ public class AttachedFileRegistry {
   /**
    * Moves pending files into per-conversation storage under the given
    * conversation ID, then clears the pending set.
+   *
+   * @param conversationId the conversation ID to associate with pending files.
    */
   public void flushPending(String conversationId) {
     if (StringUtils.isBlank(conversationId) || pendingFiles.isEmpty()) {
@@ -71,6 +75,9 @@ public class AttachedFileRegistry {
 
   /**
    * Records files for an existing conversation (continued turns).
+   *
+   * @param conversationId the conversation ID to associate with the files.
+   * @param filePaths the file paths to record as attached files.
    */
   public void addAttachedFiles(String conversationId,
       Collection<String> filePaths) {
@@ -98,6 +105,10 @@ public class AttachedFileRegistry {
   /**
    * Returns {@code true} when the given file was explicitly attached
    * by the user — either in the pending set or for the given conversation.
+   *
+   * @param conversationId the conversation ID to check.
+   * @param filePath the file path to check.
+   * @return {@code true} if the file was explicitly attached; {@code false} otherwise.
    */
   public boolean isAttachedFile(String conversationId, String filePath) {
     if (StringUtils.isBlank(filePath)) {
@@ -112,7 +123,11 @@ public class AttachedFileRegistry {
     return paths != null && paths.contains(key);
   }
 
-  /** Removes all tracked data for a conversation. */
+  /**
+   * Removes all tracked data for a conversation.
+   *
+   * @param conversationId the conversation ID whose tracked data should be removed.
+   */
   public void clearConversation(String conversationId) {
     attachedPaths.remove(conversationId);
   }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/ConfirmationHandler.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/ConfirmationHandler.java
@@ -78,7 +78,11 @@ public interface ConfirmationHandler {
     // no-op by default
   }
 
-  /** Clears session-scoped approvals for the given conversation. */
+  /**
+   * Clears session-scoped approvals for the given conversation.
+   *
+   * @param conversationId the conversation ID whose session-scoped approvals should be cleared.
+   */
   default void clearSession(String conversationId) {
     // no-op by default
   }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/ConfirmationService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/confirmation/ConfirmationService.java
@@ -46,6 +46,9 @@ public class ConfirmationService {
 
     /**
      * Resolves a CLS toolType string to a ToolCategory.
+     *
+     * @param value the CLS tool type string to resolve.
+     * @return the matching tool category, or {@link #UNKNOWN} when no category matches.
      */
     public static ToolCategory fromValue(String value) {
       if (value != null) {
@@ -95,6 +98,7 @@ public class ConfirmationService {
    *
    * @param params the confirmation request parameters
    * @param sessionConversationId the conversation ID for session-scoped lookups
+   * @return the confirmation result indicating whether prompting is required.
    */
   public ConfirmationResult evaluate(
       InvokeClientToolConfirmationParams params,
@@ -136,7 +140,11 @@ public class ConfirmationService {
     }
   }
 
-  /** Clears session-scoped approvals for a conversation across all handlers. */
+  /**
+   * Clears session-scoped approvals for a conversation across all handlers.
+   *
+   * @param conversationId the conversation ID whose session-scoped approvals should be cleared.
+   */
   public void clearSession(String conversationId) {
     for (ConfirmationHandler handler : handlers.values()) {
       handler.clearSession(conversationId);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/contextwindow/ContextSizeDonut.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/contextwindow/ContextSizeDonut.java
@@ -36,6 +36,9 @@ public class ContextSizeDonut {
 
   /**
    * Creates the donut canvas as a child of {@code parent} and wires it to the given service.
+   *
+   * @param parent the parent composite that will contain the donut canvas.
+   * @param contextWindowService the context window service providing context size data.
    */
   public ContextSizeDonut(Composite parent, ContextWindowService contextWindowService) {
     this.contextWindowService = contextWindowService;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/AgentToolService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/AgentToolService.java
@@ -67,6 +67,8 @@ public class AgentToolService implements ToolInvocationListener, TerminalService
 
   /**
    * Constructor for AgentToolService.
+   *
+   * @param lsConnection the language server connection used to register and invoke tools.
    */
   public AgentToolService(CopilotLanguageServerConnection lsConnection) {
     this.tools = new ConcurrentHashMap<>();
@@ -198,6 +200,8 @@ public class AgentToolService implements ToolInvocationListener, TerminalService
 
   /**
    * Bind the chat view to the auth status.
+   *
+   * @param chatView the chat view to bind to this service.
    */
   public void bindChatView(ChatView chatView) {
     if (chatView == null) {
@@ -220,6 +224,8 @@ public class AgentToolService implements ToolInvocationListener, TerminalService
    * Invoke a tool by its name.
    *
    * @param toolName The name of the tool to invoke
+   * @param input the input payload to pass to the tool.
+   * @param chatView the chat view associated with the invocation, or null if none.
    * @return The result of the tool invocation, or null if the tool was not found
    */
   public CompletableFuture<LanguageModelToolResult[]> invokeTool(String toolName, @Nullable Map<String, Object> input,
@@ -345,7 +351,11 @@ public class AgentToolService implements ToolInvocationListener, TerminalService
     return confirmationService;
   }
 
-  /** Returns the registry of user-attached context files. */
+  /**
+   * Returns the registry of user-attached context files.
+   *
+   * @return the registry of user-attached context files.
+   */
   public AttachedFileRegistry getAttachedFileRegistry() {
     return attachedFileRegistry;
   }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/AvatarService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/AvatarService.java
@@ -43,6 +43,8 @@ public class AvatarService {
 
   /**
    * Avatar Service.
+   *
+   * @param authStatusManager the authentication status manager used to resolve the current user.
    */
   public AvatarService(AuthStatusManager authStatusManager) {
     this.authStatusManager = authStatusManager;
@@ -78,6 +80,8 @@ public class AvatarService {
 
   /**
    * Gets the avatar for the copilot.
+   *
+   * @return the default Copilot avatar image.
    */
   public Image getAvatarForCopilot() {
     return defaultGithubAvatar;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokService.java
@@ -61,6 +61,8 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Constructor.
+   *
+   * @param lsConnection the language server connection used for BYOK operations.
    */
   public ByokService(CopilotLanguageServerConnection lsConnection) {
     super(lsConnection, null);
@@ -89,6 +91,8 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Bind a ByokPreferencePage to this service for automatic updates.
+   *
+   * @param page the BYOK preference page to update from observable state.
    */
   public void bindByokPreferencePage(ByokPreferencePage page) {
     ensureRealm(() -> {
@@ -140,6 +144,8 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Load API keys from persistent storage.
+   *
+   * @return a future that completes when API keys have been loaded.
    */
   public CompletableFuture<Void> loadApiKeys() {
     return lsConnection.listByokApiKeys(new ByokApiKey(null, null)).thenAccept(response -> {
@@ -170,6 +176,8 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Load BYOK models from persistent storage.
+   *
+   * @return a future that completes when local BYOK models have been loaded.
    */
   public CompletableFuture<Void> loadLocalModels() {
     return lsConnection.listByokModels(new ByokListModelParams(null, false)).thenAccept(response -> {
@@ -186,6 +194,8 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Refresh BYOK data (including API keys and models).
+   *
+   * @return a future that completes when BYOK data has been refreshed.
    */
   public CompletableFuture<Void> refreshData() {
     return loadApiKeys().thenCompose(unused -> loadProviderUrls()).thenCompose(unused -> loadLocalModels());
@@ -244,6 +254,9 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Save a BYOK model. Sequence: saveModel() -> loadLocalModels(PROVIDER).
+   *
+   * @param model the BYOK model to save.
+   * @return a future that completes when the model has been saved and local models have been reloaded.
    */
   public CompletableFuture<Void> saveModel(ByokModel model) {
     return lsConnection.saveByokModel(model).thenCompose(response -> {
@@ -257,6 +270,9 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Delete a BYOK model. Sequence: deleteModel() -> loadLocalModels(PROVIDER).
+   *
+   * @param model the BYOK model to delete.
+   * @return a future that completes when the model has been deleted and local models have been reloaded.
    */
   public CompletableFuture<Void> deleteModel(ByokModel model) {
     return lsConnection.deleteByokModel(model).thenCompose(response -> {
@@ -272,6 +288,10 @@ public class ByokService extends ChatBaseService {
    * Add API key and register models. Flow: saveApiKey -> listRemoteModels(provider, true) -> batchSave(models
    * registered) -> refreshData(PROVIDER). rollbackOnListFailure=true means if list fails (e.g. invalid key) we delete
    * the just-saved key.
+   *
+   * @param providerName the display name of the provider for the API key.
+   * @param apiKey the API key to save.
+   * @return a future that completes when the key has been added and BYOK data has been refreshed.
    */
   public CompletableFuture<Void> addApiKey(String providerName, String apiKey) {
     ByokApiKey key = new ByokApiKey(providerName, null);
@@ -301,6 +321,10 @@ public class ByokService extends ChatBaseService {
   /**
    * Change an existing API key. Flow: saveApiKey -> listRemoteModels(provider, true) -> mergeRemoteWithLocal()
    * ->refreshData(PROVIDER)
+   *
+   * @param providerName the display name of the provider whose API key is changing.
+   * @param newApiKey the replacement API key to save.
+   * @return a future that completes when the key has been changed and BYOK data has been refreshed.
    */
   public CompletableFuture<Void> changeApiKey(String providerName, String newApiKey) {
     ByokApiKey key = new ByokApiKey(providerName, null);
@@ -322,6 +346,9 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Delete API key for a provider. Sequence: deleteApiKey() -> refreshData(PROVIDER)
+   *
+   * @param providerName the display name of the provider whose API key should be deleted.
+   * @return a future that completes when the key has been deleted and BYOK data has been refreshed.
    */
   public CompletableFuture<Void> deleteApiKey(String providerName) {
     ByokApiKey byokApiKey = new ByokApiKey(providerName, null);
@@ -337,6 +364,9 @@ public class ByokService extends ChatBaseService {
 
   /**
    * Reload a single provider's complete data (API keys, local models, and remote models if applicable).
+   *
+   * @param providerName the display name of the provider to reload.
+   * @return a future that completes when the provider data has been reloaded.
    */
   public CompletableFuture<Void> reloadProvider(String providerName) {
     if (ByokModelProvider.isAzure(providerName)) {
@@ -373,6 +403,8 @@ public class ByokService extends ChatBaseService {
   /**
    * Reload all providers sequentially to avoid file write conflicts. Providers with API keys and Ollama with a
    * configured URL will fetch remote models; Azure only uses its locally stored model configurations.
+   *
+   * @return a future that completes when all eligible providers have been reloaded.
    */
   public CompletableFuture<Void> reloadAllProviders() {
     return fetchAllProvidersSequentially().thenCompose(unused -> refreshData());
@@ -440,6 +472,9 @@ public class ByokService extends ChatBaseService {
   /**
    * Fetch remote models (remote=true) for a specific provider and merge new ones into local storage. Returns true if
    * new models were added (and saved), false otherwise.
+   *
+   * @param providerName the display name of the provider whose remote models should be fetched.
+   * @return a future that completes with true if new models were added, or false otherwise.
    */
   public CompletableFuture<Boolean> fetchProviderModels(String providerName) {
     return lsConnection.listByokModels(new ByokListModelParams(providerName, true)).thenCompose(response -> {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
@@ -52,6 +52,9 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
 
   /**
    * Constructor for the SlashCommandService.
+   *
+   * @param lsConnection the language server connection used to list conversation templates.
+   * @param authStatusManager the authentication status manager used to refresh commands on sign-in changes.
    */
   public ChatCompletionService(CopilotLanguageServerConnection lsConnection, AuthStatusManager authStatusManager) {
     this.authStatusManager = authStatusManager;
@@ -130,6 +133,9 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
   /**
    * Returns templates filtered by the scope appropriate for the given chat mode. In Agent mode only {@code agent-panel}
    * scoped templates (including skills) are shown; in Ask mode only {@code chat-panel} scoped templates are shown.
+   *
+   * @param chatMode the chat mode used to choose the template scope.
+   * @return the templates available for the given chat mode.
    */
   public ConversationTemplate[] getFilteredTemplates(ChatMode chatMode) {
     String scope = chatMode == ChatMode.Agent ? CopilotScope.AGENT_PANEL : CopilotScope.CHAT_PANEL;
@@ -141,6 +147,7 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
    * Find a broken slash command in the given text.
    *
    * @param text the text
+   * @param cursorPosition the cursor position within the text.
    * @return the start and end index of the broken slash command
    */
   public boolean isBrokenCommand(String text, int cursorPosition) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatServiceManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatServiceManager.java
@@ -63,6 +63,8 @@ public class ChatServiceManager implements IChatServiceManager {
 
   /**
    * Get the authentication status manager.
+   *
+   * @return the authentication status manager.
    */
   public AuthStatusManager getAuthStatusManager() {
     return authStatusManager;
@@ -177,6 +179,8 @@ public class ChatServiceManager implements IChatServiceManager {
 
   /**
    * Get the MCP extension point manager.
+   *
+   * @return the MCP extension point manager.
    */
   public McpExtensionPointManager getMcpExtensionPointManager() {
     return mcpExtensionPointManager;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpConfigService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpConfigService.java
@@ -112,6 +112,8 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
 
   /**
    * Bind the observable with UI in McpAutoApproveSection.
+   *
+   * @param section the MCP auto-approve section to bind.
    */
   public void bindWithAutoApproveSection(McpAutoApproveSection section) {
     ensureRealm(() -> {
@@ -134,6 +136,8 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
 
   /**
    * Bind the observable with UI in McpPreferencePage.
+   *
+   * @param page the MCP preference page to bind.
    */
   public void bindWithMcpPreferencePage(McpPreferencePage page) {
     ensureRealm(() -> {
@@ -166,6 +170,11 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
 
   /**
    * Bind the observable with mcpToolButton in ActionBar.
+   *
+   * @param mcpToolButton the action bar button that opens MCP tools.
+   * @param mcpToolImage the image to show when MCP tools are enabled.
+   * @param mcpToolDisabledImage the image to show when MCP tools are disabled.
+   * @param mcpToolDetectedImage the image to show when new extension MCP registrations are detected.
    */
   public void bindWithMcpToolButton(Button mcpToolButton, Image mcpToolImage, Image mcpToolDisabledImage,
       Image mcpToolDetectedImage) {
@@ -222,6 +231,7 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
   /**
    * Handles the Dynamic OAuth request from MCP servers.
    *
+   * @param request the OAuth request describing the fields to collect.
    * @return a map of input field names to values, or null if the user cancelled
    */
   public Map<String, String> mcpOauth(McpOauthRequest request) {
@@ -246,6 +256,8 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
 
   /**
    * Check if there is any new MCP registration from extension point.
+   *
+   * @return true if a new extension MCP registration was found, or false otherwise.
    */
   public boolean isNewExtMcpRegFound() {
     Boolean[] result = new Boolean[1];
@@ -255,6 +267,8 @@ public class McpConfigService extends ChatBaseService implements IMcpConfigServi
 
   /**
    * Set the newExtMcpRegFound flag.
+   *
+   * @param value true when a new extension MCP registration was found, or false otherwise.
    */
   public void setNewExtMcpRegFound(boolean value) {
     ensureRealm(() -> newExtMcpRegFoundObservableValue.setValue(value));

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpExtensionPointManager.java
@@ -61,6 +61,8 @@ public class McpExtensionPointManager {
 
   /**
    * Constructor for McpExtensionPointManager.
+   *
+   * @param mcpConfigService the MCP configuration service to update with extension registration state.
    */
   public McpExtensionPointManager(McpConfigService mcpConfigService) {
     gson = new GsonBuilder().disableHtmlEscaping().create();
@@ -339,6 +341,8 @@ public class McpExtensionPointManager {
 
   /**
    * Process MCP registration from extension point.
+   *
+   * @return the approved MCP server configuration JSON, or null if no registrations were found.
    */
   public String approveExtMcpRegistration() {
     Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
@@ -444,6 +448,8 @@ public class McpExtensionPointManager {
 
   /**
    * Check if there is any MCP registration from extension point.
+   *
+   * @return true if extension MCP registrations are available, or false otherwise.
    */
   public synchronized boolean hasExtMcpRegistration() {
     return !extMcpInfoMap.isEmpty();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpRuntimeLogger.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/McpRuntimeLogger.java
@@ -107,6 +107,8 @@ public class McpRuntimeLogger {
 
   /**
    * Print a message to the MCP Runtime console.
+   *
+   * @param mcpRuntimeLog the MCP runtime log entry to print.
    */
   public void println(McpRuntimeLog mcpRuntimeLog) {
     Objects.requireNonNull(mcpRuntimeLog, "McpRuntimeLog entry cannot be null");

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ModelService.java
@@ -78,6 +78,9 @@ public class ModelService extends ChatBaseService {
 
   /**
    * Constructor for the ModelService.
+   *
+   * @param lsConnection the language server connection used to fetch model information.
+   * @param authStatusManager the authentication status manager used to react to sign-in changes.
    */
   public ModelService(CopilotLanguageServerConnection lsConnection, AuthStatusManager authStatusManager) {
     super(lsConnection, authStatusManager);
@@ -432,6 +435,8 @@ public class ModelService extends ChatBaseService {
 
   /**
    * Check if the active model supports vision capabilities.
+   *
+   * @return true if the active model supports vision, or false otherwise.
    */
   public boolean isVisionSupported() {
     CopilotModel model = getActiveModel();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ReferencedFileService.java
@@ -208,6 +208,8 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
   /**
    * Binds the current file widget to the current file observable.
+   *
+   * @param widget the current referenced file widget to bind.
    */
   public void bindCurrentFileWidget(CurrentReferencedFile widget) {
     unbindCurrentFileWidget();
@@ -253,6 +255,8 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
   /**
    * Binds the action bar with the referenced files observable.
+   *
+   * @param actionBar the action bar to update when referenced files change.
    */
   public void bindReferencedFilesWidget(ActionBar actionBar) {
     ensureRealm(() -> {
@@ -380,6 +384,8 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
   /**
    * Update the referenced files observable with a new set of files.
+   *
+   * @param files the resources to set as referenced files.
    */
   public void updateReferencedFiles(List<IResource> files) {
     ensureRealm(() -> {
@@ -391,6 +397,8 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
   /**
    * Add files to the existing referenced files observable.
+   *
+   * @param files the resources to add to the referenced files.
    */
   public void addReferencedFiles(List<IResource> files) {
     ensureRealm(() -> {
@@ -423,6 +431,8 @@ public class ReferencedFileService extends ChatBaseService implements IReference
 
   /**
    * Remove a specific resource from the referenced files observable.
+   *
+   * @param targetResource the resource to remove from the referenced files.
    */
   public void removeReferencedFile(IResource targetResource) {
     ensureRealm(() -> {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/TodoListService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/TodoListService.java
@@ -38,6 +38,8 @@ public class TodoListService extends ChatBaseService implements ChatProgressList
 
   /**
    * Constructor.
+   *
+   * @param lsConnection the language server connection used by the user preference service base class.
    */
   public TodoListService(CopilotLanguageServerConnection lsConnection) {
     super(lsConnection, null);
@@ -55,6 +57,8 @@ public class TodoListService extends ChatBaseService implements ChatProgressList
 
   /**
    * Bind the TodoListBar to the given ChatView.
+   *
+   * @param chatView the chat view that owns the todo list bar.
    */
   public void bindTodoListBar(ChatView chatView) {
     this.boundChatView = chatView;
@@ -109,6 +113,8 @@ public class TodoListService extends ChatBaseService implements ChatProgressList
 
   /**
    * Get the current list of todo items.
+   *
+   * @return a copy of the current todo items.
    */
   public List<TodoItem> getTodoList() {
     List<TodoItem> result = new ArrayList<>();
@@ -164,6 +170,8 @@ public class TodoListService extends ChatBaseService implements ChatProgressList
 
   /**
    * Determine if the Clear button should be disabled.
+   *
+   * @return true if the Clear button should be disabled, or false otherwise.
    */
   public boolean shouldDisableClearButton() {
     if (!isRequestInProgress()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/UserPreferenceService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/UserPreferenceService.java
@@ -63,6 +63,9 @@ public class UserPreferenceService extends ChatBaseService implements CopilotAut
 
   /**
    * Constructor for the UserPreferenceService.
+   *
+   * @param lsConnection the language server connection used to read and persist user preferences.
+   * @param authStatusManager the authentication status manager used to react to sign-in changes.
    */
   public UserPreferenceService(CopilotLanguageServerConnection lsConnection, AuthStatusManager authStatusManager) {
     super(lsConnection, authStatusManager);
@@ -479,6 +482,8 @@ public class UserPreferenceService extends ChatBaseService implements CopilotAut
   /**
    * Bind the chat view to automatically switch between Ask and Agent layouts when the active mode changes.
    * This creates a side effect that rebuilds the view whenever activeChatModeObservable changes.
+   *
+   * @param chatView the chat view to rebuild when the active mode changes.
    */
   public void bindChatView(ChatView chatView) {
     if (chatView == null) {
@@ -511,6 +516,8 @@ public class UserPreferenceService extends ChatBaseService implements CopilotAut
 
   /**
    * Add input to the input history.
+   *
+   * @param input the input text to add to history.
    */
   public void addInputToHistory(String input) {
     inputNavigation.add(input);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/tools/BaseTool.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/tools/BaseTool.java
@@ -21,11 +21,17 @@ public abstract class BaseTool {
 
   /**
    * Invoke the tool.
+   *
+   * @param input the input arguments for the tool invocation.
+   * @param chatView the chat view requesting the tool invocation.
+   * @return a future completed with the language model tool results.
    */
   public abstract CompletableFuture<LanguageModelToolResult[]> invoke(Map<String, Object> input, ChatView chatView);
 
   /**
    * Get the registration information of the tool.
+   *
+   * @return the language model tool registration information.
    */
   public LanguageModelToolInformation getToolInformation() {
     LanguageModelToolInformation toolInfo = new LanguageModelToolInformation();
@@ -37,6 +43,8 @@ public abstract class BaseTool {
 
   /**
    * Needs user's confirmation to continue.
+   *
+   * @return {@code true} if the tool requires user confirmation; {@code false} otherwise.
    */
   public boolean needConfirmation() {
     return false;
@@ -44,6 +52,8 @@ public abstract class BaseTool {
 
   /**
    * Get confirmed messages.
+   *
+   * @return the confirmation messages for this tool.
    */
   public ConfirmationMessages getConfirmationMessages() {
     return new ConfirmationMessages();
@@ -51,6 +61,8 @@ public abstract class BaseTool {
 
   /**
    * Get the user input.
+   *
+   * @return the user input for this tool, or {@code null} if none is available.
    */
   @Nullable
   public Map<String, Object> getInput() {
@@ -59,6 +71,8 @@ public abstract class BaseTool {
 
   /**
    * Get the name of the tool.
+   *
+   * @return the tool name.
    */
   public String getToolName() {
     return name;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/tools/FileToolService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/tools/FileToolService.java
@@ -45,6 +45,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Constructor for FileToolService.
+   *
+   * @param lsConnection the Copilot language server connection.
    */
   public FileToolService(CopilotLanguageServerConnection lsConnection) {
     super(lsConnection, null);
@@ -62,6 +64,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Bind the WorkingSetBar to the changed files.
+   *
+   * @param chatView the chat view that owns the working set bar.
    */
   public void bindWorkingSetBar(ChatView chatView) {
     if (this.createFileTool == null) {
@@ -142,6 +146,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Enable or disable the buttons for the working set bar.
+   *
+   * @param status {@code true} to enable the buttons; {@code false} to disable them.
    */
   public void setWorkingSetBarButtonStatus(boolean status) {
     ensureRealm(() -> {
@@ -151,6 +157,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Set the changed files for the working set bar.
+   *
+   * @param files the changed files to show in the working set bar.
    */
   public void setChangedFiles(Map<ChangedFile, FileChangeProperty> files) {
     ensureRealm(() -> {
@@ -160,6 +168,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Get the changed files for the working set bar.
+   *
+   * @return the changed files currently shown in the working set bar.
    */
   public Map<ChangedFile, FileChangeProperty> getChangedFiles() {
     return filesObservable.getValue();
@@ -167,6 +177,8 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Get the WorkingSetBar instance.
+   *
+   * @return the working set bar instance.
    */
   public WorkingSetBar getWorkingSetBar() {
     return workingSetBar;
@@ -174,6 +186,9 @@ public class FileToolService extends ChatBaseService {
 
   /**
    * Add a changed file to the working set bar.
+   *
+   * @param file the changed file to add.
+   * @param fileChangeType the type of change for the file.
    */
   public void addChangedFile(ChangedFile file, FileChangeType fileChangeType) {
     ensureRealm(() -> {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BaseCompletionManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BaseCompletionManager.java
@@ -96,6 +96,11 @@ public abstract class BaseCompletionManager implements KeyListener, MouseListene
   /**
    * Creates a new completion manager. The manager is responsible for trigger the completion, apply suggestions to the
    * document. And schedule the rendering of ghost text.
+   *
+   * @param lsConnection the connection to the Copilot language server.
+   * @param provider the completion provider that supplies suggestions.
+   * @param editor the text editor managed by this completion manager.
+   * @param settingsManager the language server settings manager.
    */
   public BaseCompletionManager(CopilotLanguageServerConnection lsConnection, CompletionProvider provider,
       ITextEditor editor, LanguageServerSettingManager settingsManager) {
@@ -399,6 +404,8 @@ public abstract class BaseCompletionManager implements KeyListener, MouseListene
 
   /**
    * Accept completion suggestion.
+   *
+   * @param type the kind of suggestion acceptance to perform.
    */
   public void acceptSuggestion(AcceptSuggestionType type) {
     try {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BlockGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BlockGhostText.java
@@ -22,7 +22,7 @@ import com.microsoft.copilot.eclipse.ui.utils.CompletionUtils;
 public class BlockGhostText extends GhostText {
 
   /**
-   * Creates a new EolGhostText.
+   * Creates a new BlockGhostText.
    *
    * @param text the ghost text to display.
    * @param modelOffset the model offset where the ghost text starts.

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BlockGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/BlockGhostText.java
@@ -23,6 +23,10 @@ public class BlockGhostText extends GhostText {
 
   /**
    * Creates a new EolGhostText.
+   *
+   * @param text the ghost text to display.
+   * @param modelOffset the model offset where the ghost text starts.
+   * @param document the document containing the ghost text.
    */
   public BlockGhostText(String text, int modelOffset, IDocument document) {
     super(text, modelOffset, GhostTextType.BLOCK_LINE);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/CompletionManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/CompletionManager.java
@@ -33,6 +33,11 @@ public class CompletionManager extends BaseCompletionManager {
   /**
    * Creates a new completion manager. The manager is responsible for trigger the completion, apply suggestions to the
    * document. And schedule the rendering of ghost text.
+   *
+   * @param lsConnection the connection to the Copilot language server.
+   * @param provider the completion provider that supplies suggestions.
+   * @param editor the text editor managed by this completion manager.
+   * @param settingsManager the language server settings manager.
    */
   public CompletionManager(CopilotLanguageServerConnection lsConnection, CompletionProvider provider,
       ITextEditor editor, LanguageServerSettingManager settingsManager) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/CompletionManagerLegacy.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/CompletionManagerLegacy.java
@@ -27,6 +27,11 @@ public class CompletionManagerLegacy extends BaseCompletionManager {
 
   /**
    * Creates a new legacy completion manager for environments without code mining support.
+   *
+   * @param lsConnection the connection to the Copilot language server.
+   * @param provider the completion provider that supplies suggestions.
+   * @param editor the text editor managed by this completion manager.
+   * @param settingsManager the language server settings manager.
    */
   public CompletionManagerLegacy(CopilotLanguageServerConnection lsConnection, CompletionProvider provider,
       ITextEditor editor, LanguageServerSettingManager settingsManager) {
@@ -94,6 +99,7 @@ public class CompletionManagerLegacy extends BaseCompletionManager {
    * @param documentLine the line in the document where the completion is triggered.
    * @param completionLine the first line of the inline suggestion.
    * @param triggerOffset the offset where the completion is triggered in the document.
+   * @return the ghost texts to render for the completion.
    */
   public static List<GhostText> getGhostTexts(String documentLine, String completionLine, int triggerOffset) {
     List<GhostText> ghostTexts = new ArrayList<>();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorLifecycleListener.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorLifecycleListener.java
@@ -47,6 +47,9 @@ public class EditorLifecycleListener implements IPartListener2 {
 
   /**
    * Creates a new EditorLifecycleListener.
+   *
+   * @param languageServer the connection to the Copilot language server.
+   * @param manager the editors manager that owns completion managers.
    */
   public EditorLifecycleListener(CopilotLanguageServerConnection languageServer, EditorsManager manager) {
     this.languageServer = languageServer;
@@ -67,6 +70,8 @@ public class EditorLifecycleListener implements IPartListener2 {
 
   /**
    * Used to prepare the active editor part when the IDE is opened.
+   *
+   * @param editorPart the editor part to activate.
    */
   public void partActivated(IEditorPart editorPart) {
     ITextEditor textEditor = editorPart.getAdapter(ITextEditor.class);
@@ -196,6 +201,8 @@ public class EditorLifecycleListener implements IPartListener2 {
 
   /**
    * Creates the {@link BaseCompletionManager} for the ITextEditor of the IWorkbenchPart.
+   *
+   * @param textEditor the text editor to create a completion handler for.
    */
   public void createCompletionHandlerFor(ITextEditor textEditor) {
     if (textEditor != null) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorsManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EditorsManager.java
@@ -35,6 +35,11 @@ public class EditorsManager {
 
   /**
    * Creates a new EditorManager.
+   *
+   * @param languageServer the connection to the Copilot language server.
+   * @param completionProvider the provider that supplies completion suggestions.
+   * @param nesProvider the provider that supplies next edit suggestions.
+   * @param settingsManager the language server settings manager.
    */
   public EditorsManager(CopilotLanguageServerConnection languageServer, CompletionProvider completionProvider,
       NextEditSuggestionProvider nesProvider, LanguageServerSettingManager settingsManager) {
@@ -51,6 +56,9 @@ public class EditorsManager {
    * Gets the {@link com.microsoft.copilot.eclipse.ui.completion.BaseCompletionManager BaseCompletionManager} for the
    * given ITextEditor. If it does not exist, a new one will be created. Returns <code>null</code> if the editor is
    * <code>null</code>.
+   *
+   * @param textEditor the text editor whose completion manager should be returned or created.
+   * @return the completion manager for the editor, or <code>null</code> if none can be created.
    */
   @Nullable
   public BaseCompletionManager getOrCreateCompletionManagerFor(ITextEditor textEditor) {
@@ -78,6 +86,9 @@ public class EditorsManager {
   /**
    * Gets the {@link com.microsoft.copilot.eclipse.ui.completion.BaseCompletionManager BaseCompletionManager} for the
    * given ITextEditor. Returns <code>null</code> if there is no manager for the editor.
+   *
+   * @param editor the editor whose completion manager should be returned.
+   * @return the completion manager for the editor, or <code>null</code> if none exists.
    */
   @Nullable
   public BaseCompletionManager getCompletionManagerFor(IEditorPart editor) {
@@ -91,6 +102,8 @@ public class EditorsManager {
   /**
    * Gets the {@link com.microsoft.copilot.eclipse.ui.completion.BaseCompletionManager BaseCompletionManager} for the
    * active ITextEditor.
+   *
+   * @return the completion manager for the active editor, or <code>null</code> if none exists.
    */
   @Nullable
   public BaseCompletionManager getActiveCompletionManager() {
@@ -103,6 +116,8 @@ public class EditorsManager {
   /**
    * Disposes the {@link com.microsoft.copilot.eclipse.ui.completion.BaseCompletionManager BaseCompletionManager} for
    * the given ITextEditor.
+   *
+   * @param textEditor the text editor whose completion manager should be disposed.
    */
   public void disposeCompletionManagerFor(ITextEditor textEditor) {
     if (textEditor == null) {
@@ -116,6 +131,8 @@ public class EditorsManager {
 
   /**
    * Sets the active editor.
+   *
+   * @param textEditor the text editor to mark as active.
    */
   public void setActiveEditor(ITextEditor textEditor) {
     this.activeEditor.set(textEditor);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EolGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/EolGhostText.java
@@ -18,6 +18,9 @@ public class EolGhostText extends GhostText {
 
   /**
    * Creates a new EolGhostText.
+   *
+   * @param text the ghost text to display.
+   * @param modelOffset the model offset where the ghost text starts.
    */
   public EolGhostText(String text, int modelOffset) {
     super(text, modelOffset, GhostTextType.END_OF_LINE);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/GhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/GhostText.java
@@ -31,6 +31,10 @@ public abstract class GhostText {
 
   /**
    * Draws the ghost text.
+   *
+   * @param styledText the styled text control where the ghost text is drawn.
+   * @param widgetOffset the widget offset where drawing starts.
+   * @param gc the graphics context used for drawing.
    */
   public abstract void draw(StyledText styledText, int widgetOffset, GC gc);
 

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/InlineGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/InlineGhostText.java
@@ -19,6 +19,9 @@ public class InlineGhostText extends GhostText {
 
   /**
    * Creates a new InlineGhostText.
+   *
+   * @param text the ghost text to display.
+   * @param modelOffset the model offset where the ghost text starts.
    */
   public InlineGhostText(String text, int modelOffset) {
     super(text, modelOffset, GhostTextType.IN_LINE);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/RenderingManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/RenderingManager.java
@@ -39,6 +39,8 @@ public class RenderingManager implements PaintListener {
 
   /**
    * Creates a new CompletionManager.
+   *
+   * @param textViewer the text viewer whose ghost text should be rendered.
    */
   public RenderingManager(ITextViewer textViewer) {
     this.ghostTexts = new ArrayList<>();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/RenderingManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/RenderingManager.java
@@ -38,7 +38,7 @@ public class RenderingManager implements PaintListener {
   private boolean needDisposeColorResource;
 
   /**
-   * Creates a new CompletionManager.
+   * Creates a new RenderingManager.
    *
    * @param textViewer the text viewer whose ghost text should be rendered.
    */

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/BlockGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/BlockGhostText.java
@@ -17,6 +17,11 @@ public class BlockGhostText extends LineHeaderCodeMining {
 
   /**
    * Creates a new BlockGhostText.
+   *
+   * @param beforeLineNumber the line number before which the block ghost text is displayed.
+   * @param document the document containing the block ghost text.
+   * @param provider the code mining provider creating this ghost text.
+   * @param text the ghost text to display.
    */
   public BlockGhostText(int beforeLineNumber, IDocument document, ICodeMiningProvider provider, String text)
       throws BadLocationException {
@@ -26,6 +31,10 @@ public class BlockGhostText extends LineHeaderCodeMining {
 
   /**
    * Creates a new BlockGhostText. (for testing purpose)
+   *
+   * @param position the position where the block ghost text is displayed.
+   * @param provider the code mining provider creating this ghost text.
+   * @param text the ghost text to display.
    */
   public BlockGhostText(Position position, ICodeMiningProvider provider, String text) throws BadLocationException {
     super(position, provider, null);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/LineContentGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/LineContentGhostText.java
@@ -16,6 +16,11 @@ public class LineContentGhostText extends LineContentCodeMining {
 
   /**
    * Creates a new LineContentCodeMining.
+   *
+   * @param position the position where the line content ghost text is displayed.
+   * @param afterPosition whether the ghost text is displayed after the position.
+   * @param provider the code mining provider creating this ghost text.
+   * @param text the ghost text to display.
    */
   public LineContentGhostText(Position position, boolean afterPosition, ICodeMiningProvider provider, String text)
       throws BadLocationException {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/LineEndGhostText.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/completion/codemining/LineEndGhostText.java
@@ -16,6 +16,11 @@ public class LineEndGhostText extends LineEndCodeMining {
 
   /**
    * Creates a new LineEndGhostText.
+   *
+   * @param document the document containing the line end ghost text.
+   * @param line the line where the ghost text is displayed.
+   * @param provider the code mining provider creating this ghost text.
+   * @param text the ghost text to display.
    */
   public LineEndGhostText(IDocument document, int line, ICodeMiningProvider provider, String text)
       throws BadLocationException {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpRegistryDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpRegistryDialog.java
@@ -79,6 +79,8 @@ public class McpRegistryDialog extends Dialog {
 
   /**
    * Create the MCP registry dialog.
+   *
+   * @param parentShell the parent shell for the dialog.
    */
   public McpRegistryDialog(Shell parentShell) {
     super(parentShell);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpServerDetailDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpServerDetailDialog.java
@@ -74,6 +74,7 @@ public class McpServerDetailDialog extends Dialog implements EventHandler {
    * @param parentShell The parent shell.
    * @param serverResponse The server response to display.
    * @param installManager Install manager from parent dialog.
+   * @param mcpRegistryBaseUrl The base URL of the MCP registry.
    */
   public McpServerDetailDialog(Shell parentShell, ServerResponse serverResponse, McpServerInstallManager installManager,
       String mcpRegistryBaseUrl) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpServerInstallManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/dialogs/mcp/McpServerInstallManager.java
@@ -123,6 +123,9 @@ public class McpServerInstallManager {
 
   /**
    * Installs a server configuration using event-driven approach.
+   *
+   * @param serverName the name of the server to install.
+   * @param serverConfig the server configuration to install.
    */
   public void installServer(String serverName, JsonObject serverConfig) {
     // Check for server name conflict before proceeding
@@ -211,6 +214,8 @@ public class McpServerInstallManager {
 
   /**
    * Uninstalls a server configuration using event-driven approach.
+   *
+   * @param serverName the name of the server to uninstall.
    */
   public void uninstallServer(String serverName) {
     // Publish uninstall start event
@@ -312,6 +317,10 @@ public class McpServerInstallManager {
 
   /**
    * Determines the initial state based on whether the server is installed.
+   *
+   * @param serverId the server identifier to check.
+   * @param url the registry URL associated with the server.
+   * @return the initial button state for the server.
    */
   public ButtonState getInitialState(String serverId, String url) {
     return isServerInstalled(serverId, url) ? ButtonState.UNINSTALL : ButtonState.INSTALL;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/handlers/CopilotHandler.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/handlers/CopilotHandler.java
@@ -19,6 +19,8 @@ import com.microsoft.copilot.eclipse.ui.nes.RenderManager;
 public abstract class CopilotHandler extends AbstractHandler {
   /**
    * Gets the active {@link BaseCompletionManager} for the current editor.
+   *
+   * @return the active completion manager, or <code>null</code> if none is available.
    */
   @Nullable
   public BaseCompletionManager getActiveCompletionManager() {
@@ -39,6 +41,8 @@ public abstract class CopilotHandler extends AbstractHandler {
 
   /**
    * Gets the active {@link RenderManager} for the current editor.
+   *
+   * @return the active next edit suggestion render manager, or <code>null</code> if none is available.
    */
   @Nullable
   public RenderManager getActiveNesRenderManager() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/handlers/QuotaTextCalculator.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/handlers/QuotaTextCalculator.java
@@ -73,6 +73,8 @@ public class QuotaTextCalculator {
   /**
    * Returns the tooltip used for the premium requests row. CFI (Copilot for Individuals) plans get
    * the "included credits" tooltip; all other paid plans get the "monthly limit" tooltip.
+   *
+   * @return the tooltip text for the premium requests row.
    */
   public String getPremiumRequestsTooltip() {
     if (MenuUtils.isCfiPlan(quotaResult.copilotPlan())) {
@@ -83,6 +85,8 @@ public class QuotaTextCalculator {
 
   /**
    * Returns the aligned text for code completions quota.
+   *
+   * @return the aligned code completions quota text.
    */
   public String getCompletionText() {
     return getAlignedQuotaText(Messages.menu_quota_codeCompletions, getPercentUsed(quotaResult.completions()));
@@ -90,6 +94,8 @@ public class QuotaTextCalculator {
 
   /**
    * Returns the aligned text for chat messages quota.
+   *
+   * @return the aligned chat messages quota text.
    */
   public String getChatText() {
     return getAlignedQuotaText(Messages.menu_quota_chatMessages, getPercentUsed(quotaResult.chat()));
@@ -99,6 +105,8 @@ public class QuotaTextCalculator {
    * Returns the aligned text for the monthly limit row, sourced from the premium interactions quota.
    * CFI (Copilot for Individuals) plans label this row "Included credits" and display the absolute
    * "{used}/{entitlement} AI credits used" suffix instead of a percentage.
+   *
+   * @return the aligned premium requests quota text.
    */
   public String getPremiumRequestsText() {
     return getAlignedQuotaText(getPremiumRequestsLabel(), getPremiumRequestsSuffix());
@@ -109,6 +117,8 @@ public class QuotaTextCalculator {
    * Returns the aligned text for the legacy "Premium Requests" row used when token-based billing is
    * not enabled on the language server. Preserves the original main-branch label and "{percent}%"
    * suffix.
+   *
+   * @return the aligned legacy premium requests quota text.
    */
   public String getPremiumText() {
     return getAlignedQuotaText(Messages.menu_quota_premiumRequests,

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/ActionMenu.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/ActionMenu.java
@@ -40,6 +40,8 @@ public class ActionMenu {
 
   /**
    * Checks if the action menu is currently open.
+   *
+   * @return true if the action menu is open, false otherwise.
    */
   public boolean isOpen() {
     return activeMenu != null && !activeMenu.isDisposed() && activeMenu.isVisible();
@@ -57,6 +59,9 @@ public class ActionMenu {
 
   /**
    * Shows the action menu at the specified coordinates.
+   *
+   * @param x the x-coordinate relative to the styled text.
+   * @param y the y-coordinate relative to the styled text.
    */
   public void show(int x, int y) {
     if (text == null || text.isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/BottomBar.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/BottomBar.java
@@ -36,6 +36,9 @@ public class BottomBar {
 
   /**
    * Constructor.
+   *
+   * @param text the styled text that owns the bottom bar.
+   * @param jumpAction the action to run when the bar is clicked.
    */
   public BottomBar(StyledText text, Runnable jumpAction) {
     this.text = text;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/DiffPopup.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/DiffPopup.java
@@ -56,6 +56,13 @@ public class DiffPopup {
 
   /**
    * Update popup position and show it.
+   *
+   * @param text the styled text containing the suggestion.
+   * @param editorViewer the text viewer for the editor.
+   * @param file the file whose content is shown in the popup.
+   * @param range the LSP range covered by the suggestion.
+   * @param indentPos the editor position used to apply vertical indentation.
+   * @param model the diff model to display in the popup.
    */
   public void updatePosition(StyledText text, ITextViewer editorViewer, IFile file, Range range, Position indentPos,
       RenderManager.DiffModel model) {
@@ -86,6 +93,10 @@ public class DiffPopup {
 
   /**
    * Hide popup and clear editor indentation.
+   *
+   * @param text the styled text whose indentation should be cleared.
+   * @param editorViewer the text viewer for the editor.
+   * @param indentPos the editor position used for indentation.
    */
   public void hideAndClearIndent(StyledText text, ITextViewer editorViewer, Position indentPos) {
     if (text == null || text.isDisposed()) {
@@ -400,7 +411,10 @@ public class DiffPopup {
   /**
    * Get current indentation info for RulerColumn to clear. Calculates based on current position.
    *
-   * @return int array [widgetLine, height], or null if no indentation applied
+   * @param text the styled text containing the applied indentation.
+   * @param viewer the text viewer used to map indentation positions.
+   * @param indentPos the editor position where indentation was applied.
+   * @return int array [widgetLine, height], or null if no indentation applied.
    */
   public int[] getAppliedIndentInfo(StyledText text, ITextViewer viewer, Position indentPos) {
     if (appliedIndentHeight <= 0) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/InlineHighlighter.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/InlineHighlighter.java
@@ -45,7 +45,12 @@ public class InlineHighlighter {
   private Color lineBgColor;
   private LineBackgroundListener lineBackgroundListener;
 
-  /** Constructor. Does not register listeners - call registerListeners() from UI thread. */
+  /**
+   * Constructor. Does not register listeners - call registerListeners() from UI thread.
+   *
+   * @param viewer the text viewer whose document is highlighted.
+   * @param text the styled text that renders line highlights.
+   */
   public InlineHighlighter(ITextViewer viewer, StyledText text) {
     this.viewer = viewer;
     this.text = text;
@@ -105,7 +110,14 @@ public class InlineHighlighter {
 
   }
 
-  /** Apply annotation + line highlight based on diff spans. */
+  /**
+   * Apply annotation + line highlight based on diff spans.
+   *
+   * @param diffModel the diff model containing original, replacement, and span information.
+   * @param startOffset the start offset of the suggestion in the document.
+   * @param endOffset the end offset of the suggestion in the document.
+   * @param lspRange the LSP range covered by the suggestion.
+   */
   public void apply(RenderManager.DiffModel diffModel, int startOffset, int endOffset, Range lspRange) {
     clear();
     if (diffModel == null || viewer == null) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RenderManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RenderManager.java
@@ -72,6 +72,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
     /**
      * Checks if this is a pure deletion (has original text but no replacement).
+     *
+     * @return true if this model represents a pure deletion, false otherwise.
      */
     public boolean isPureDelete() {
       return StringUtils.isNotBlank(original) && StringUtils.isBlank(replacement);
@@ -79,6 +81,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
     /**
      * Checks if this is a pure insertion (has replacement text but no original).
+     *
+     * @return true if this model represents a pure insertion, false otherwise.
      */
     public boolean isPureInsert() {
       return StringUtils.isBlank(original) && StringUtils.isNotBlank(replacement);
@@ -112,6 +116,10 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Constructor. Mirrors BaseCompletionManager pattern: accepts ITextEditor and extracts viewer/text internally.
+   *
+   * @param lsConnection the language server connection used for NES telemetry and document versions.
+   * @param nesProvider the provider that supplies next edit suggestions.
+   * @param editor the text editor managed by this renderer.
    */
   public RenderManager(CopilotLanguageServerConnection lsConnection, NextEditSuggestionProvider nesProvider,
       ITextEditor editor) {
@@ -168,6 +176,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Attach a ruler column after controller creation. Safe to call repeatedly; only the first effective column is used.
+   *
+   * @param col the ruler column to attach.
    */
   public synchronized void attachColumn(RulerColumn col) {
     if (col == null || col == this.column) {
@@ -183,6 +193,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Detach the current column (e.g. when UI column disposed) without disposing controller so suggestions keep flowing.
+   *
+   * @param col the ruler column to detach.
    */
   public synchronized void detachColumn(RulerColumn col) {
     if (this.column == col) {
@@ -270,6 +282,10 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Show suggestion UI for the given model line and texts.
+   *
+   * @param modelLine the model line where the suggestion starts.
+   * @param removed the original text removed by the suggestion.
+   * @param added the replacement text added by the suggestion.
    */
   public void showSuggestion(int modelLine, String removed, String added) {
     if (text == null) {
@@ -376,6 +392,9 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Open the action (accept / reject) menu at the given StyledText-relative coordinates.
+   *
+   * @param textX the x-coordinate relative to the styled text.
+   * @param textY the y-coordinate relative to the styled text.
    */
   public void openActionMenu(int textX, int textY) {
     SwtUtils.invokeOnDisplayThread(() -> {
@@ -459,6 +478,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
 
   /**
    * Get the current suggestion line number in the document, or null if no active suggestion.
+   *
+   * @return the current suggestion line number, or -1 if no suggestion line is available.
    */
   public int getSuggestionLine() {
     if (suggestionStartPosition == null || suggestionStartPosition.isDeleted()) {
@@ -868,6 +889,8 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
   /**
    * Handle a TAB action: if the suggestion line is in the current viewport, accept it; otherwise scroll (jump) to
    * reveal it (centered approximately). Returns true if a suggestion was present and action handled, false otherwise.
+   *
+   * @return true if a suggestion was present and handled, false otherwise.
    */
   public boolean handleTabAcceptOrReveal() {
     if (!hasActiveSuggestion() || text == null || text.isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RenderManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RenderManager.java
@@ -477,7 +477,7 @@ public class RenderManager implements NextEditSuggestionListener, ITextListener,
   }
 
   /**
-   * Get the current suggestion line number in the document, or null if no active suggestion.
+   * Get the current suggestion line number in the document, or -1 if no active suggestion.
    *
    * @return the current suggestion line number, or -1 if no suggestion line is available.
    */

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RulerColumn.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/RulerColumn.java
@@ -321,6 +321,9 @@ public class RulerColumn extends AbstractRulerColumn implements IContributedRule
    * Clear indentation area in ruler column by manually filling with background color. This is needed because
    * indentation area doesn't correspond to any text line, the icon in indentation area will not be cleared when redraw
    * is called.
+   *
+   * @param widgetLine the widget line before the indentation area.
+   * @param height the height of the indentation area to clear.
    */
   public void clearIndentationArea(int widgetLine, int height) {
     Control c = getControl();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/TextDiffCalculator.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/nes/TextDiffCalculator.java
@@ -28,6 +28,14 @@ public class TextDiffCalculator {
 
     /**
      * Constructor.
+     *
+     * @param type the type of diff represented by this span.
+     * @param origStart the start offset in the original text.
+     * @param origLength the length in the original text.
+     * @param newStart the start offset in the replacement text.
+     * @param newLength the length in the replacement text.
+     * @param origText the original differing text.
+     * @param newText the replacement differing text.
      */
     public DualDiffSpan(DiffSegment.Type type, int origStart, int origLength, int newStart, int newLength,
         String origText, String newText) {
@@ -51,7 +59,12 @@ public class TextDiffCalculator {
     /** Replacement text (before normalization). */
     public final String replacementText;
 
-    /** Constructor. */
+    /**
+     * Constructor.
+     *
+     * @param originalText the original text before normalization.
+     * @param replacementText the replacement text before normalization.
+     */
     public DualDiffResult(String originalText, String replacementText) {
       this.originalText = originalText;
       this.replacementText = replacementText;
@@ -204,6 +217,10 @@ public class TextDiffCalculator {
 
   /**
    * Calculate character-level differences (legacy method, delegates to calculateDiff).
+   *
+   * @param original the original text to compare.
+   * @param replacement the replacement text to compare.
+   * @return the calculated dual diff result.
    */
   public static DualDiffResult calculateDualCharacterDiff(String original, String replacement) {
     return calculateDiff(original, replacement);
@@ -211,6 +228,11 @@ public class TextDiffCalculator {
 
   /**
    * Calculate character-level differences (legacy method with ignore flag).
+   *
+   * @param original the original text to compare.
+   * @param replacement the replacement text to compare.
+   * @param ignoreLineEndingDiff whether line ending differences should be ignored.
+   * @return the calculated dual diff result.
    */
   public static DualDiffResult calculateDualCharacterDiff(String original, String replacement,
       boolean ignoreLineEndingDiff) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/AddApiKeyDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/AddApiKeyDialog.java
@@ -42,6 +42,10 @@ public class AddApiKeyDialog extends TrayDialog {
 
   /**
    * Constructor for AddApiKeyDialog.
+   *
+   * @param parentShell the parent shell for the dialog.
+   * @param providerName the provider name shown in the dialog.
+   * @param onSave the callback invoked with the saved API key.
    */
   public AddApiKeyDialog(Shell parentShell, String providerName, Consumer<String> onSave) {
     this(parentShell, providerName, null, onSave);
@@ -49,6 +53,11 @@ public class AddApiKeyDialog extends TrayDialog {
 
   /**
    * Constructor for ChangeApiKeyDialog with existing API key.
+   *
+   * @param parentShell the parent shell for the dialog.
+   * @param providerName the provider name shown in the dialog.
+   * @param existingApiKey the existing API key to edit.
+   * @param onSave the callback invoked with the saved API key.
    */
   public AddApiKeyDialog(Shell parentShell, String providerName, String existingApiKey, Consumer<String> onSave) {
     super(parentShell);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/AddByokModelDialog.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/AddByokModelDialog.java
@@ -51,6 +51,10 @@ public class AddByokModelDialog extends TrayDialog {
 
   /**
    * Create the dialog.
+   *
+   * @param parentShell the parent shell for the dialog.
+   * @param providerName the provider name for the model being added.
+   * @param onSave the callback invoked with the saved BYOK model.
    */
   public AddByokModelDialog(Shell parentShell, String providerName, Consumer<ByokModel> onSave) {
     super(parentShell);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ByokPreferencePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/ByokPreferencePage.java
@@ -538,6 +538,8 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
   // ========================= Data Binding Update Entry Points =========================
   /**
    * Called by service to update models display.
+   *
+   * @param modelsByProvider the BYOK models grouped by provider name.
    */
   public void updateModelsDisplay(Map<String, List<ByokModel>> modelsByProvider) {
     if (viewer != null && !viewer.getControl().isDisposed()) {
@@ -566,6 +568,8 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
 
   /**
    * Called by service to update API keys display.
+   *
+   * @param apiKeys the API keys keyed by provider name.
    */
   public void updateApiKeysDisplay(Map<String, String> apiKeys) {
     if (viewer != null && !viewer.getControl().isDisposed()) {
@@ -602,6 +606,8 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
   // ========================= State Management =========================
   /**
    * Update page loading state.
+   *
+   * @param isLoading true to show the loading overlay, or false to show the model tree.
    */
   public void setPageLoading(boolean isLoading) {
     if (viewerStack == null || viewerStack.isDisposed()) {
@@ -620,6 +626,9 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
 
   /**
    * Set loading state for a specific provider.
+   *
+   * @param providerName the provider name whose loading state should change.
+   * @param isLoading true if the provider is loading, or false otherwise.
    */
   public void setProviderLoading(String providerName, boolean isLoading) {
     if (isLoading) {
@@ -637,6 +646,8 @@ public class ByokPreferencePage extends PreferencePage implements IWorkbenchPref
 
   /**
    * Handle all types of errors with unified logic based on message prefix.
+   *
+   * @param errorMessage the error message to display or handle.
    */
   public void handleError(String errorMessage) {
     if (errorMessage == null) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/FileOperationAutoApproveSection.java
@@ -70,7 +70,12 @@ public class FileOperationAutoApproveSection extends Composite {
   private Button resetButton;
   private Button unmatchedCheckbox;
 
-  /** Creates the file-operation auto-approve section inside the given parent. */
+  /**
+   * Creates the file-operation auto-approve section inside the given parent.
+   *
+   * @param parent the parent composite for this section.
+   * @param style the SWT style bits for this section.
+   */
   public FileOperationAutoApproveSection(Composite parent, int style) {
     super(parent, style);
     setLayout(new GridLayout(1, false));
@@ -335,7 +340,11 @@ public class FileOperationAutoApproveSection extends Composite {
     return true;
   }
 
-  /** Loads file-operation rules and unmatched-file-operation preference from the store. */
+  /**
+   * Loads file-operation rules and unmatched-file-operation preference from the store.
+   *
+   * @param store the preference store to load settings from.
+   */
   public void loadFromPreferences(IPreferenceStore store) {
     List<FileOperationAutoApproveRule> savedRules = parseSavedRules(store);
 
@@ -487,7 +496,11 @@ public class FileOperationAutoApproveSection extends Composite {
     allRules.addAll(userRules);
   }
 
-  /** Saves file-operation rules and unmatched-file-operation preference to the store. */
+  /**
+   * Saves file-operation rules and unmatched-file-operation preference to the store.
+   *
+   * @param store the preference store to save settings to.
+   */
   public void saveToPreferences(IPreferenceStore store) {
     // Save all rules (defaults + user) to preferences.
     // On next load, defaults are re-identified by pattern matching.

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/GlobalAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/GlobalAutoApproveSection.java
@@ -29,7 +29,12 @@ public class GlobalAutoApproveSection extends Composite {
 
   private Button yoloCheckbox;
 
-  /** Creates the global auto-approve section inside the given parent. */
+  /**
+   * Creates the global auto-approve section inside the given parent.
+   *
+   * @param parent the parent composite for this section.
+   * @param style the SWT style bits for this section.
+   */
   public GlobalAutoApproveSection(Composite parent, int style) {
     super(parent, style);
     setLayout(new GridLayout(1, false));
@@ -90,13 +95,21 @@ public class GlobalAutoApproveSection extends Composite {
       Messages.preferences_page_global_auto_approve_confirm_message);
   }
 
-  /** Loads global auto-approve settings from the preference store. */
+  /**
+   * Loads global auto-approve settings from the preference store.
+   *
+   * @param store the preference store to load settings from.
+   */
   public void loadFromPreferences(IPreferenceStore store) {
     yoloCheckbox.setSelection(
         store.getBoolean(Constants.AUTO_APPROVE_YOLO_MODE));
   }
 
-  /** Saves global auto-approve settings to the preference store. */
+  /**
+   * Saves global auto-approve settings to the preference store.
+   *
+   * @param store the preference store to save settings to.
+   */
   public void saveToPreferences(IPreferenceStore store) {
     store.setValue(Constants.AUTO_APPROVE_YOLO_MODE,
         yoloCheckbox.getSelection());

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
@@ -70,6 +70,10 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
 
   /**
    * Initializes the LanguageServerSettingManager.
+   *
+   * @param conn the language server connection to update with settings.
+   * @param proxyService the proxy service whose changes should be observed.
+   * @param preferenceStore the preference store that backs language server settings.
    */
   public LanguageServerSettingManager(CopilotLanguageServerConnection conn, IProxyService proxyService,
       IPreferenceStore preferenceStore) {
@@ -235,6 +239,8 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
 
   /**
    * Synchronizes the configuration with the language server.
+   *
+   * @param singleSetting the single settings object to send to the language server.
    */
   public void syncSingleConfiguration(CopilotLanguageServerSettings singleSetting) {
     DidChangeConfigurationParams params = new DidChangeConfigurationParams();
@@ -595,6 +601,7 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
   /**
    * Gets the preference store.
    *
+   * @param listener the listener to register for preference changes.
    */
   public void registerPropertyChangeListener(IPropertyChangeListener listener) {
     if (preferenceStore == null) {
@@ -619,6 +626,8 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
 
   /**
    * Gets the if auto show completions is enabled.
+   *
+   * @return true if auto show completions is enabled, or false otherwise.
    */
   public boolean isAutoShowCompletionEnabled() {
     return preferenceStore.getBoolean(Constants.AUTO_SHOW_COMPLETION);
@@ -626,6 +635,8 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
 
   /**
    * Enable or disable auto show completions.
+   *
+   * @param autoShowCompletion true to enable auto show completions, or false to disable them.
    */
   public void setAutoShowCompletion(boolean autoShowCompletion) {
     preferenceStore.setValue(Constants.AUTO_SHOW_COMPLETION, autoShowCompletion);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/LanguageServerSettingManager.java
@@ -625,7 +625,7 @@ public class LanguageServerSettingManager implements IProxyChangeListener, IProp
   }
 
   /**
-   * Gets the if auto show completions is enabled.
+   * Returns whether auto show completions is enabled.
    *
    * @return true if auto show completions is enabled, or false otherwise.
    */

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpAutoApproveSection.java
@@ -55,7 +55,12 @@ public class McpAutoApproveSection extends Composite {
   private final Set<String> checkedServers = new HashSet<>();
   private final Set<String> checkedTools = new HashSet<>();
 
-  /** Creates the MCP auto-approve section inside the given parent. */
+  /**
+   * Creates the MCP auto-approve section inside the given parent.
+   *
+   * @param parent the parent composite for this section.
+   * @param style the SWT style bits for this section.
+   */
   public McpAutoApproveSection(Composite parent, int style) {
     super(parent, style);
     setLayout(new GridLayout(1, false));
@@ -102,7 +107,11 @@ public class McpAutoApproveSection extends Composite {
     treeViewer.setInput(serverCollections);
   }
 
-  /** Loads MCP auto-approve settings from the preference store. */
+  /**
+   * Loads MCP auto-approve settings from the preference store.
+   *
+   * @param store the preference store to load settings from.
+   */
   public void loadFromPreferences(IPreferenceStore store) {
     trustAnnotationsCheckbox.setSelection(
         store.getBoolean(Constants.AUTO_APPROVE_TRUST_TOOL_ANNOTATIONS));
@@ -125,7 +134,11 @@ public class McpAutoApproveSection extends Composite {
     refreshTreeCheckState();
   }
 
-  /** Saves MCP auto-approve settings to the preference store. */
+  /**
+   * Saves MCP auto-approve settings to the preference store.
+   *
+   * @param store the preference store to save settings to.
+   */
   public void saveToPreferences(IPreferenceStore store) {
     store.setValue(Constants.AUTO_APPROVE_TRUST_TOOL_ANNOTATIONS,
         trustAnnotationsCheckbox.getSelection());
@@ -139,6 +152,8 @@ public class McpAutoApproveSection extends Composite {
   /**
    * Updates the server/tool collections displayed in the tree viewer.
    * Called from the MCP config service when server data changes.
+   *
+   * @param collections the server and tool collections to display.
    */
   public void updateServerCollections(
       List<McpServerToolsCollection> collections) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpPreferencePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/McpPreferencePage.java
@@ -591,6 +591,8 @@ public class McpPreferencePage extends FieldEditorPreferencePage implements IWor
 
   /**
    * Displays the server names and tool names in the tools group using a tree view.
+   *
+   * @param servers the MCP servers and their tools to display.
    */
   public void displayServerToolsInfo(List<McpServerToolsCollection> servers) {
     if (toolsGroup == null || toolsGroup.isDisposed()) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/preferences/TerminalAutoApproveSection.java
@@ -49,7 +49,12 @@ public class TerminalAutoApproveSection extends Composite {
   private Button resetButton;
   private Button unmatchedCheckbox;
 
-  /** Creates the terminal auto-approve section inside the given parent. */
+  /**
+   * Creates the terminal auto-approve section inside the given parent.
+   *
+   * @param parent the parent composite for this section.
+   * @param style the SWT style bits for this section.
+   */
   public TerminalAutoApproveSection(Composite parent, int style) {
     super(parent, style);
     setLayout(new GridLayout(1, false));
@@ -246,7 +251,11 @@ public class TerminalAutoApproveSection extends Composite {
     return true;
   }
 
-  /** Loads terminal rules and unmatched-command preference from the store. */
+  /**
+   * Loads terminal rules and unmatched-command preference from the store.
+   *
+   * @param store the preference store to load settings from.
+   */
   public void loadFromPreferences(IPreferenceStore store) {
     String json = store.getString(Constants.AUTO_APPROVE_TERMINAL_RULES);
     rules.clear();
@@ -269,7 +278,11 @@ public class TerminalAutoApproveSection extends Composite {
     updateButtonState();
   }
 
-  /** Saves terminal rules and unmatched-command preference to the store. */
+  /**
+   * Saves terminal rules and unmatched-command preference to the store.
+   *
+   * @param store the preference store to save settings to.
+   */
   public void saveToPreferences(IPreferenceStore store) {
     store.setValue(Constants.AUTO_APPROVE_TERMINAL_RULES,
         new Gson().toJson(rules));

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/quickstart/FeaturePage.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/quickstart/FeaturePage.java
@@ -55,6 +55,8 @@ public class FeaturePage extends Composite {
 
   /**
    * Creates a FeaturePage with colors appropriate for the current theme.
+   *
+   * @param parent the parent composite for this feature page.
    */
   public FeaturePage(Composite parent) {
     super(parent, SWT.NONE);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/CssConstants.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/CssConstants.java
@@ -35,6 +35,9 @@ public class CssConstants {
 
   /**
    * Get the placeholder color for input fields based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the placeholder color for input fields.
    */
   public static Color getInputPlaceHolderColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -45,6 +48,9 @@ public class CssConstants {
 
   /**
    * Get the border color for UI elements based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the border color.
    */
   public static Color getBorderColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -55,6 +61,9 @@ public class CssConstants {
 
   /**
    * Get the separator color for dropdown popup groups based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the separator color.
    */
   public static Color getSeparatorColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -65,6 +74,9 @@ public class CssConstants {
 
   /**
    * Get the button focus background color based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the button focus background color.
    */
   public static Color getButtonFocusBgColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -75,6 +87,9 @@ public class CssConstants {
 
   /**
    * Get the background color for dropdown popup based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the dropdown popup background color.
    */
   public static Color getPopupBgColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -85,6 +100,9 @@ public class CssConstants {
 
   /**
    * Returns the color for the "Powerful" model picker category badge.
+   *
+   * @param display the display used to create the color.
+   * @return the Powerful category badge color.
    */
   public static Color getCategoryPowerfulColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -95,6 +113,9 @@ public class CssConstants {
 
   /**
    * Returns the color for the "Versatile" model picker category badge.
+   *
+   * @param display the display used to create the color.
+   * @return the Versatile category badge color.
    */
   public static Color getCategoryVersatileColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -105,6 +126,9 @@ public class CssConstants {
 
   /**
    * Returns the color for the "Lightweight" model picker category badge.
+   *
+   * @param display the display used to create the color.
+   * @return the Lightweight category badge color.
    */
   public static Color getCategoryLightweightColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -115,6 +139,9 @@ public class CssConstants {
 
   /**
    * Get the focused background color for dropdown popup items based on the current theme.
+   *
+   * @param display the display used to create the color.
+   * @return the focused popup item background color.
    */
   public static Color getPopupItemFocusBgColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -125,6 +152,9 @@ public class CssConstants {
 
   /**
    * Get the focus border color for widgets.
+   *
+   * @param display the display used to create the color.
+   * @return the widget focus border color.
    */
   public static Color getWidgetFocusBorderColor(Display display) {
     return new Color(display, 55, 134, 246);
@@ -132,6 +162,9 @@ public class CssConstants {
 
   /**
    * Get the border color for the currently selected/focused item in list-like widgets (chat history, popup menus).
+   *
+   * @param display the display used to create the color.
+   * @return the selected item border color.
    */
   public static Color getSelectedItemBorderColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -142,6 +175,9 @@ public class CssConstants {
 
   /**
    * Returns the background color used to highlight replace text for next edit suggestions.
+   *
+   * @param display the display used to create the color.
+   * @return the replace background color for next edit suggestions.
    */
   public static Color getNesReplaceBackground(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -152,6 +188,9 @@ public class CssConstants {
 
   /**
    * Returns the background color used to highlight insert text for next edit suggestions.
+   *
+   * @param display the display used to create the color.
+   * @return the insert background color for next edit suggestions.
    */
   public static Color getNesInsertBackground(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -162,6 +201,9 @@ public class CssConstants {
 
   /**
    * Returns the highlight color used to highlight replace text for next edit suggestions.
+   *
+   * @param display the display used to create the color.
+   * @return the replace highlight color for next edit suggestions.
    */
   public static Color getNesReplaceHighlight(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -173,6 +215,9 @@ public class CssConstants {
 
   /**
    * Returns the highlight color used to highlight insert text for next edit suggestions.
+   *
+   * @param display the display used to create the color.
+   * @return the insert highlight color for next edit suggestions.
    */
   public static Color getNesInsertHighlight(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -183,6 +228,9 @@ public class CssConstants {
 
   /**
    * Returns the border color for the NES bottom bar.
+   *
+   * @param display the display used to create the color.
+   * @return the next edit suggestion bottom bar border color.
    */
   public static Color getNesBottomBarBorderColor(Display display) {
     return new Color(display, 53, 132, 241);
@@ -190,6 +238,9 @@ public class CssConstants {
 
   /**
    * Returns the color for the filled portion of the context size donut.
+   *
+   * @param display the display used to create the color.
+   * @return the filled portion color for the context size donut.
    */
   public static Color getDonutFilledColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -200,6 +251,9 @@ public class CssConstants {
 
   /**
    * Returns the warning color for the filled portion when utilisation is high (>= 90%).
+   *
+   * @param display the display used to create the color.
+   * @return the high-utilisation warning color for the context size donut.
    */
   public static Color getDonutWarningColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -210,6 +264,9 @@ public class CssConstants {
 
   /**
    * Returns the color for the track portion of the context size donut.
+   *
+   * @param display the display used to create the color.
+   * @return the track portion color for the context size donut.
    */
   public static Color getDonutTrackColor(Display display) {
     if (UiUtils.isDarkTheme()) {
@@ -220,6 +277,9 @@ public class CssConstants {
 
   /**
    * Returns the active (blue) fill color for the usage bar.
+   *
+   * @param display the display used to create the color.
+   * @return the active fill color for the usage bar.
    */
   public static Color getUsageBarActiveColor(Display display) {
     return new Color(display, 53, 116, 240);
@@ -227,6 +287,9 @@ public class CssConstants {
 
   /**
    * Returns the approaching (yellow) fill color for the usage bar.
+   *
+   * @param display the display used to create the color.
+   * @return the approaching-limit fill color for the usage bar.
    */
   public static Color getUsageBarApproachingColor(Display display) {
     return new Color(display, 255, 184, 36);
@@ -234,6 +297,9 @@ public class CssConstants {
 
   /**
    * Returns the exhausted (red) fill color for the usage bar.
+   *
+   * @param display the display used to create the color.
+   * @return the exhausted-limit fill color for the usage bar.
    */
   public static Color getUsageBarExhaustedColor(Display display) {
     return new Color(display, 224, 81, 81);
@@ -241,6 +307,9 @@ public class CssConstants {
 
   /**
    * Returns the remaining (gray) track color for the usage bar.
+   *
+   * @param display the display used to create the color.
+   * @return the remaining-capacity track color for the usage bar.
    */
   public static Color getUsageBarRemainingColor(Display display) {
     return new Color(display, 223, 225, 229);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/WrapLabel.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/swt/WrapLabel.java
@@ -25,6 +25,9 @@ public class WrapLabel {
 
   /**
    * Create a new wrap label.
+   *
+   * @param parent the parent composite for the label.
+   * @param style the SWT style bits for the label.
    */
   public WrapLabel(Composite parent, int style) {
     label = new Label(parent, style | SWT.WRAP);
@@ -41,6 +44,8 @@ public class WrapLabel {
 
   /**
    * Set the text of the label.
+   *
+   * @param text the text to show in the label.
    */
   public void setText(String text) {
     label.setText(text);
@@ -48,6 +53,8 @@ public class WrapLabel {
 
   /**
    * Set the text color of the label.
+   *
+   * @param color the foreground color for the label.
    */
   public void setForeground(Color color) {
     label.setForeground(color);
@@ -55,6 +62,8 @@ public class WrapLabel {
 
   /**
    * Set the font of the label.
+   *
+   * @param font the font to apply to the label.
    */
   public void setFont(Font font) {
     label.setFont(font);
@@ -62,6 +71,8 @@ public class WrapLabel {
 
   /**
    * Get the location of the label.
+   *
+   * @return the label location relative to its parent.
    */
   public Point getLocation() {
     return label.getLocation();
@@ -73,6 +84,8 @@ public class WrapLabel {
 
   /**
    * Set the grid layout data of the label.
+   *
+   * @param layoutData the grid layout data to apply.
    */
   public void setLayoutData(GridData layoutData) {
     label.setLayoutData(layoutData);
@@ -80,6 +93,8 @@ public class WrapLabel {
 
   /**
    * Set the row layout data of the label using RowData.
+   *
+   * @param layoutData the row layout data to apply.
    */
   public void setLayoutData(RowData layoutData) {
     label.setLayoutData(layoutData);
@@ -91,6 +106,8 @@ public class WrapLabel {
 
   /**
    * Set the dispose listener of the label.
+   *
+   * @param listener the dispose listener to add.
    */
   public void addDisposeListener(DisposeListener listener) {
     label.addDisposeListener(listener);
@@ -102,6 +119,8 @@ public class WrapLabel {
 
   /**
    * Get the visibility of the label.
+   *
+   * @return true if the label is visible, false otherwise.
    */
   public boolean getVisible() {
     return label.getVisible();
@@ -109,6 +128,8 @@ public class WrapLabel {
 
   /**
    * Set the visibility of the label.
+   *
+   * @param visible true to show the label, false to hide it.
    */
   public void setVisible(boolean visible) {
     label.setVisible(visible);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/AccessibilityUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/AccessibilityUtils.java
@@ -25,6 +25,9 @@ public class AccessibilityUtils {
 
   /**
    * Adds an accessibility name to the given UI component.
+   *
+   * @param control the control to receive the accessibility name.
+   * @param name the accessibility name to expose.
    */
   public static void addAccessibilityNameForUiComponent(Control control, String name) {
     addAccessibilityPropertiesForUiComponent(control, name, null);
@@ -32,6 +35,9 @@ public class AccessibilityUtils {
 
   /**
    * Adds an accessibility description to the given UI component.
+   *
+   * @param control the control to receive the accessibility description.
+   * @param description the accessibility description to expose.
    */
   public static void addAccessibilityDescriptionForUiComponent(Control control, String description) {
     addAccessibilityPropertiesForUiComponent(control, null, description);
@@ -39,6 +45,10 @@ public class AccessibilityUtils {
 
   /**
    * Adds accessibility name and description to the given UI component.
+   *
+   * @param control the control to receive the accessibility properties.
+   * @param name the accessibility name to expose.
+   * @param description the accessibility description to expose.
    */
   public static void addAccessibilityPropertiesForUiComponent(Control control, String name, String description) {
     control.getAccessible().addAccessibleListener(new AccessibleAdapter() {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/McpUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/McpUtils.java
@@ -59,6 +59,7 @@ public class McpUtils {
    * <li>If admin does not set any registry URL, users can set any registry URL in the IDE.</li>
    * </ol>
    *
+   * @param allowList the MCP registry allowlist to inspect.
    * @return The selected MCP registry URL, or an empty string if no valid URL is available
    */
   public static String parseMcpRegistryBaseUrlFromAllowList(McpRegistryAllowList allowList) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/MenuUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/MenuUtils.java
@@ -35,6 +35,9 @@ public final class MenuUtils {
 
   /**
    * Returns the localized plan label for the given plan, or {@code null} if the plan is unknown.
+   *
+   * @param plan the Copilot plan to label.
+   * @return the localized plan label, or {@code null} if the plan is unknown.
    */
   public static String getPlanLabel(CopilotPlan plan) {
     if (plan == null) {
@@ -60,6 +63,9 @@ public final class MenuUtils {
 
   /**
    * Returns the percent-remaining used to pick the usage icon, based on the user's plan.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return the percent of quota remaining for icon selection.
    */
   public static double calculatePercentRemaining(CheckQuotaResult quotaStatus) {
     CopilotPlan plan = quotaStatus.copilotPlan();
@@ -80,6 +86,9 @@ public final class MenuUtils {
 
   /**
    * Returns the image descriptor for the usage row based on the lowest percentRemaining.
+   *
+   * @param percentRemaining the lowest remaining quota percentage.
+   * @return the image descriptor for the matching usage icon.
    */
   public static ImageDescriptor getUsageIcon(double percentRemaining) {
     if (percentRemaining <= 10) {
@@ -93,6 +102,8 @@ public final class MenuUtils {
 
   /**
    * Returns the shared blank icon descriptor used for indented usage rows.
+   *
+   * @return the shared blank icon descriptor.
    */
   public static ImageDescriptor getBlankIcon() {
     return CopilotImages.getImageDescriptor(CopilotImages.IMG_BLANK);
@@ -100,6 +111,9 @@ public final class MenuUtils {
 
   /**
    * True when the user is on a Business / Enterprise plan with no monthly premium-interactions limit.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return {@code true} when the user's organization plan has unlimited premium interactions.
    */
   public static boolean isOrgUnlimited(CheckQuotaResult quotaStatus) {
     CopilotPlan plan = quotaStatus.copilotPlan();
@@ -114,6 +128,9 @@ public final class MenuUtils {
    * predicate gates both the Monthly limit display row and the overage upsell row ("Enable
    * Additional Usage" / "Increase Budget"): without metered premium data the upsell has no data
    * to act on and would mislead the user.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return {@code true} when the user has a metered non-org premium quota.
    */
   public static boolean hasNonOrgPremiumQuota(CheckQuotaResult quotaStatus) {
     if (quotaStatus.copilotPlan() == CopilotPlan.free) {
@@ -136,6 +153,7 @@ public final class MenuUtils {
    * @param plan the user's Copilot plan
    * @param canUpgradePlan whether the user can upgrade their Copilot plan, or {@code null} when the language
    *     server did not supply this field
+   * @return {@code true} when the Upgrade Plan row should be shown.
    */
   public static boolean shouldShowUpgradePlanRow(CopilotPlan plan, Boolean canUpgradePlan) {
     if (canUpgradePlan != null) {
@@ -147,6 +165,9 @@ public final class MenuUtils {
   /**
    * True when the plan is a CFI (Copilot for Individuals) plan: individual, individual_pro, or
    * individual_max.
+   *
+   * @param plan the Copilot plan to test.
+   * @return {@code true} when the plan is a Copilot for Individuals plan.
    */
   public static boolean isCfiPlan(CopilotPlan plan) {
     return plan == CopilotPlan.individual || plan == CopilotPlan.individual_pro
@@ -155,6 +176,9 @@ public final class MenuUtils {
 
   /**
    * Returns the label for the overage upsell row depending on the current overage state.
+   *
+   * @param premiumQuota the premium interactions quota to inspect.
+   * @return the overage upsell row label.
    */
   public static String getOverageRowLabel(Quota premiumQuota) {
     boolean overageEnabled = premiumQuota != null && premiumQuota.overagePermitted();
@@ -166,6 +190,9 @@ public final class MenuUtils {
    * for paid users when token-based billing is enabled. Renders as
    * {@code "Additional usage enabled"} or {@code "Additional usage not enabled"} depending on
    * {@link Quota#overagePermitted()}.
+   *
+   * @param premiumQuota the premium interactions quota to inspect.
+   * @return the additional usage status row label.
    */
   public static String getAdditionalUsageRowLabel(Quota premiumQuota) {
     boolean overageEnabled = premiumQuota != null && premiumQuota.overagePermitted();
@@ -177,6 +204,9 @@ public final class MenuUtils {
    * Returns the tooltip for the "Additional usage" status row, or {@code null} when no tooltip
    * applies. Business / Enterprise plans receive a plan-specific tooltip; other plans currently
    * have no tooltip.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return the additional usage row tooltip, or {@code null} when none applies.
    */
   public static String getAdditionalUsageRowTooltip(CheckQuotaResult quotaStatus) {
     CopilotPlan plan = quotaStatus.copilotPlan();
@@ -195,6 +225,9 @@ public final class MenuUtils {
    * True when the allowance-reset row should be shown. The row is hidden when there is no monthly
    * allowance to reset (premium-interactions quota is unlimited), when no reset date was supplied,
    * or when the supplied reset date cannot be parsed.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return {@code true} when the allowance-reset row should be shown.
    */
   public static boolean shouldShowAllowanceResetRow(CheckQuotaResult quotaStatus) {
     Quota premiumQuota = quotaStatus.premiumInteractions();
@@ -208,6 +241,9 @@ public final class MenuUtils {
    * True when none of the quotas tracked for the user's plan have any usage yet. For free plans this
    * means both the chat and completions quotas are at 0% used; for paid plans this means the premium
    * interactions quota is at 0% used.
+   *
+   * @param quotaStatus the quota status for the current user.
+   * @return {@code true} when none of the tracked quotas have usage.
    */
   public static boolean noUsageYet(CheckQuotaResult quotaStatus) {
     if (quotaStatus.copilotPlan() == CopilotPlan.free) {
@@ -225,6 +261,9 @@ public final class MenuUtils {
    *
    * <p>Callers <strong>must</strong> gate with {@link #shouldShowAllowanceResetRow}; this method
    * assumes a parseable reset date is present.
+   *
+   * @param quotaStatus the quota status containing usage and reset date data.
+   * @return the formatted allowance-reset row label.
    */
   public static String formatAllowanceReset(CheckQuotaResult quotaStatus) {
     if (noUsageYet(quotaStatus)) {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ModelUtils.java
@@ -32,6 +32,9 @@ public class ModelUtils {
 
   /**
    * Convert ByokModel to CopilotModel format for unified handling.
+   *
+   * @param byokModel the BYOK model to convert.
+   * @return the converted Copilot model.
    */
   public static CopilotModel convertByokModelToCopilotModel(ByokModel byokModel) {
     CopilotModel copilotModel = new CopilotModel();
@@ -172,6 +175,9 @@ public class ModelUtils {
 
   /**
    * Returns the formatted context window size for the model, or {@code null} if unavailable.
+   *
+   * @param model the model whose context window size should be formatted.
+   * @return the formatted context window size, or {@code null} if unavailable.
    */
   public static String getContextWindowText(CopilotModel model) {
     Integer contextWindow = resolveContextWindowSize(model);

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ResourceUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/ResourceUtils.java
@@ -31,6 +31,9 @@ public final class ResourceUtils {
 
   /**
    * Collect valid resources from the selection.
+   *
+   * @param selection the structured selection to inspect.
+   * @return the valid file and folder resources in the selection.
    */
   public static List<IResource> collectValidResources(IStructuredSelection selection) {
     List<IResource> validResources = new ArrayList<>();
@@ -51,6 +54,9 @@ public final class ResourceUtils {
 
   /**
    * Analyze the selection and return statistics about files, folders, and invalid resources.
+   *
+   * @param selection the structured selection to analyze.
+   * @return statistics describing the selected resources.
    */
   public static SelectionStats analyzeSelection(IStructuredSelection selection) {
     int fileCount = 0;

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/SwtUtils.java
@@ -74,6 +74,8 @@ public class SwtUtils {
 
   /**
    * Invokes the given runnable on the display thread.
+   *
+   * @param runnable the runnable to invoke.
    */
   public static void invokeOnDisplayThread(Runnable runnable) {
     Display currentDisplay = Display.getCurrent();
@@ -158,6 +160,8 @@ public class SwtUtils {
 
   /**
    * Get the active editor part from workbench.
+   *
+   * @return the active editor part, or {@code null} when none is active.
    */
   @Nullable
   public static IEditorPart getActiveEditorPart() {
@@ -176,6 +180,8 @@ public class SwtUtils {
    * window. It is more specific to the Eclipse framework and is typically used in handlers for commands or actions
    * within the Eclipse environment.
    *
+   * @param event the execution event from the handler.
+   * @return the shell associated with the active workbench window.
    * @throws ExecutionException if the active workbench window cannot be retrieved from the event.
    */
   public static Shell getShellFromEvent(ExecutionEvent event) throws ExecutionException {
@@ -184,6 +190,8 @@ public class SwtUtils {
 
   /**
    * Get current display.
+   *
+   * @return the current display, or the default display when none is current.
    */
   public static Display getDisplay() {
     Display display = Display.getCurrent();
@@ -195,6 +203,9 @@ public class SwtUtils {
 
   /**
    * Check if the given text viewer is editable.
+   *
+   * @param textViewer the text viewer to inspect.
+   * @return {@code true} when the text viewer is editable.
    */
   public static boolean isEditable(ITextViewer textViewer) {
     AtomicReference<Boolean> ref = new AtomicReference<>(false);
@@ -209,6 +220,10 @@ public class SwtUtils {
   /**
    * Redraw the block ghost texts at the given model offset. If forceRedraw is false, redraw will only be triggered when
    * the model offset if out of the text editor's visible range.
+   *
+   * @param textViewer the text viewer containing the block ghost text.
+   * @param modelOffset the model offset of the line to redraw.
+   * @param forceRedraw whether to redraw even when the line is visible.
    */
   public static void redrawBlockLineAtModelOffset(ITextViewer textViewer, int modelOffset, boolean forceRedraw) {
     if (textViewer == null || textViewer.getDocument() == null) {
@@ -256,6 +271,10 @@ public class SwtUtils {
 
   /**
    * Check if the widget offset is out of the text editor's visible range.
+   *
+   * @param textViewer the text viewer to inspect.
+   * @param widgetOffset the widget offset to test.
+   * @return {@code true} when the widget offset is outside the visible editor range.
    */
   public static boolean isWidgetOffsetOutOfTextEditorVisibleRange(ITextViewer textViewer, int widgetOffset) {
     StyledText styledText = textViewer.getTextWidget();
@@ -287,6 +306,9 @@ public class SwtUtils {
 
   /**
    * Get the registered inline annotation color.
+   *
+   * @param display the display associated with the color lookup.
+   * @return the registered inline annotation color, or {@code null} when unavailable.
    */
   @Nullable
   public static Color getRegisteredInlineAnnotationColor(Display display) {
@@ -299,6 +321,9 @@ public class SwtUtils {
 
   /**
    * Get the default ghost text color.
+   *
+   * @param display the display used to create the color.
+   * @return the default ghost text color.
    */
   public static Color getDefaultGhostTextColor(Display display) {
     return new Color(display, new RGB(DEFAULT_GHOST_TEXT_SCALE, DEFAULT_GHOST_TEXT_SCALE, DEFAULT_GHOST_TEXT_SCALE));
@@ -307,6 +332,8 @@ public class SwtUtils {
   /**
    * Forwards vertical mouse wheel scrolling from a nested scrollable to its nearest parent scroller when the nested
    * control is already at the scroll boundary.
+   *
+   * @param scrollable the nested scrollable whose mouse wheel events should be forwarded.
    */
   public static void forwardVerticalMouseWheelToParentScrollerAtBoundary(Scrollable scrollable) {
     scrollable.addListener(SWT.MouseWheel, event -> {
@@ -369,6 +396,11 @@ public class SwtUtils {
 
   /**
    * Resizes a table column to fill the table client area not occupied by the fixed-width columns.
+   *
+   * @param table the table whose client area should be filled.
+   * @param fillColumn the column to resize.
+   * @param minWidth the minimum width required before resizing the fill column.
+   * @param fixedColumns the fixed-width columns to exclude from the available width.
    */
   public static void resizeColumnToFillTable(Table table, TableColumn fillColumn,
       int minWidth, TableColumn... fixedColumns) {
@@ -388,6 +420,9 @@ public class SwtUtils {
 
   /**
    * Copy the given text to the clipboard.
+   *
+   * @param control the control used to access the display thread.
+   * @param text the text to copy.
    */
   public static void copyToClipboard(Control control, String text) {
     invokeOnDisplayThread(() -> {

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/TextMateUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/TextMateUtils.java
@@ -40,6 +40,9 @@ public class TextMateUtils {
 
   /**
    * Get or create a SourceViewerConfiguration for the given language.
+   *
+   * @param lang the language ID or file extension to configure.
+   * @return the source viewer configuration for the language.
    */
   public static SourceViewerConfiguration getConfiguration(String lang) {
     TMPresentationReconciler reconciler = new TMPresentationReconciler();

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/UiUtils.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/utils/UiUtils.java
@@ -111,6 +111,8 @@ public class UiUtils {
 
   /**
    * Get the active workbench page.
+   *
+   * @return the active workbench page, or {@code null} when none is active.
    */
   @Nullable
   public static IWorkbenchPage getActivePage() {
@@ -127,6 +129,8 @@ public class UiUtils {
 
   /**
    * Returns the file that is currently opened in the editor.
+   *
+   * @return the file from the active editor, or {@code null} when none is available.
    */
   @Nullable
   public static IFile getCurrentFile() {
@@ -154,6 +158,9 @@ public class UiUtils {
 
   /**
    * Return the IFile from the given editor part.
+   *
+   * @param editor the editor part to inspect.
+   * @return the file associated with the editor, or {@code null} when none is available.
    */
   @Nullable
   public static IFile getFileFromEditorPart(IEditorPart editor) {
@@ -178,6 +185,9 @@ public class UiUtils {
 
   /**
    * Gets the file opened in the given text editor.
+   *
+   * @param editor the text editor to inspect.
+   * @return the file opened in the text editor, or {@code null} when none is available.
    */
   @Nullable
   public static IFile getFileFromTextEditor(ITextEditor editor) {
@@ -190,6 +200,9 @@ public class UiUtils {
 
   /**
    * Gets the relative file opened in the given compare editor.
+   *
+   * @param editor the compare editor to inspect.
+   * @return the file from the compare editor, or {@code null} when none is available.
    */
   @Nullable
   public static IFile getFileFromCompareEditor(CompareEditor editor) {
@@ -206,6 +219,9 @@ public class UiUtils {
 
   /**
    * Opens the given file in an editor.
+   *
+   * @param file the workspace file to open.
+   * @return the opened editor part, or {@code null} if the file could not be opened.
    */
   public static IEditorPart openInEditor(IFile file) {
     if (file == null || !file.exists()) {
@@ -226,6 +242,9 @@ public class UiUtils {
 
   /**
    * Opens the given local filesystem file in an editor.
+   *
+   * @param file the local filesystem path to open.
+   * @return the opened editor part, or {@code null} if the file could not be opened.
    */
   public static IEditorPart openLocalFileInEditor(Path file) {
     if (file == null || !Files.exists(file)) {
@@ -247,6 +266,8 @@ public class UiUtils {
 
   /**
    * Opens the file in the editor.
+   *
+   * @return the workspace files currently opened in editors.
    */
   public static List<IFile> getOpenedFiles() {
     IWorkbenchPage page = getActivePage();
@@ -277,6 +298,8 @@ public class UiUtils {
 
   /**
    * Returns the part service.
+   *
+   * @return the active workbench window's part service, or {@code null} when unavailable.
    */
   public static IPartService getPartService() {
     IWorkbench workbench = PlatformUI.getWorkbench();
@@ -292,6 +315,9 @@ public class UiUtils {
 
   /**
    * Open the given link in a new browser page.
+   *
+   * @param link the link to open.
+   * @return {@code true} when the link was opened successfully.
    */
   public static boolean openLink(String link) {
     String encodedUrl = PlatformUtils.escapeSpaceInUrl(link);
@@ -330,6 +356,12 @@ public class UiUtils {
 
   /**
    * Resizes the given image to the given width and height.
+   *
+   * @param display the display used to create the resized image.
+   * @param originalImage the image to resize.
+   * @param width the target width in pixels.
+   * @param height the target height in pixels.
+   * @return the resized image.
    */
   public static Image resizeImage(Display display, Image originalImage, int width, int height) {
     ImageData originalData = originalImage.getImageData();
@@ -340,6 +372,10 @@ public class UiUtils {
   /**
    * Returns the widget offset that corresponds to the given offset in the viewer's input document or <code>-1</code> if
    * there is no such offset.
+   *
+   * @param textViewer the text viewer containing the input document.
+   * @param offset the model offset to convert.
+   * @return the corresponding widget offset, or <code>-1</code> when none exists.
    */
   public static int modelOffset2WidgetOffset(ITextViewer textViewer, int offset) {
     return textViewer instanceof ITextViewerExtension5 extension ? extension.modelOffset2WidgetOffset(offset) : offset;
@@ -348,6 +384,10 @@ public class UiUtils {
   /**
    * Returns the offset of the viewer's input document that corresponds to the given widget offset or <code>-1</code> if
    * there is no such offset.
+   *
+   * @param textViewer the text viewer containing the widget.
+   * @param offset the widget offset to convert.
+   * @return the corresponding model offset, or <code>-1</code> when none exists.
    */
   public static int widgetOffset2ModelOffset(ITextViewer textViewer, int offset) {
     return textViewer instanceof ITextViewerExtension5 extension ? extension.widgetOffset2ModelOffset(offset) : offset;
@@ -402,6 +442,9 @@ public class UiUtils {
 
   /**
    * Returns the index of the first word in the given text.
+   *
+   * @param text the text to inspect.
+   * @return the start and end indexes of the first word.
    */
   public static Point getFirstWordIndex(String text) {
     int start = 0;
@@ -419,6 +462,8 @@ public class UiUtils {
   /**
    * Returns the theme color with the given ID.
    *
+   * @param colorId the theme color ID to look up.
+   * @return the theme color for the ID.
    */
   public static Color getThemeColor(String colorId) {
     return PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getColorRegistry().get(colorId);
@@ -486,6 +531,7 @@ public class UiUtils {
   /**
    * Returns the view with the given ID and type.
    *
+   * @param <T> the expected view type.
    * @param viewId the ID of the view
    * @param viewType the type of the view
    * @return the view or <code>null</code> if the view is not found
@@ -506,6 +552,10 @@ public class UiUtils {
   /**
    * Create a button only with an icon. As Button is NOT intended to be subclassed, use a factory method to create a
    * custom button.
+   *
+   * @param parent the parent composite for the button.
+   * @param style the SWT style bits for the button.
+   * @return the created icon button.
    */
   public static Button createIconButton(Composite parent, int style) {
     Button result = new Button(parent, style);
@@ -561,6 +611,10 @@ public class UiUtils {
 
   /**
    * Returns a bold version of the given font.
+   *
+   * @param display the display used to create the bold font.
+   * @param originalFont the font to copy with bold styling.
+   * @return the new bold font.
    */
   public static Font getBoldFont(Display display, Font originalFont) {
     FontData[] fontData = originalFont.getFontData();
@@ -615,6 +669,7 @@ public class UiUtils {
    * @param suffix the suffix to append to each line
    * @param initialSpaceNumber the number of initial spaces to add
    * @param maxWidth the maximum width of the aligned text
+   * @return the aligned text padded to the requested width.
    */
   public static String getAlignedText(GC gc, String originalText, String fineTuneCharacter, String suffix,
       int initialSpaceNumber, int maxWidth) {


### PR DESCRIPTION
This PR

- activates the checkstyle checks for missing `@param` and `@return` entries in javadoc comments in public API
- adds missing `@param` and `@return` entries in javadoc comments

See comment https://github.com/microsoft/copilot-for-eclipse/pull/365#discussion_r3679333536