### PR TITLE
fix: Add waitUntil method for asynchronous verification in ByokService

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
@@ -17,11 +17,11 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.eclipse.swt.widgets.Display;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,6 +41,8 @@ import com.microsoft.copilot.eclipse.ui.preferences.ByokPreferencePage;
 @ExtendWith(MockitoExtension.class)
 class ByokServiceTests {
 
+  private static final long WAIT_TIMEOUT_MS = 5000;
+  private static final long WAIT_INTERVAL_MS = 25;
   private static final String OLLAMA_ENDPOINT = "http://localhost:11434";
   private static final String OLLAMA_PROVIDER = ByokModelProvider.OLLAMA.getDisplayName();
 
@@ -150,7 +152,7 @@ class ByokServiceTests {
   }
 
   private static void waitUntil(Runnable verification) {
-    long timeout = System.currentTimeMillis() + 5000;
+    long timeout = System.currentTimeMillis() + WAIT_TIMEOUT_MS;
     AssertionError lastError = null;
     while (System.currentTimeMillis() < timeout) {
       Display.getDefault().syncExec(() -> {
@@ -162,8 +164,14 @@ class ByokServiceTests {
       } catch (AssertionError e) {
         lastError = e;
       }
+      try {
+        Thread.sleep(WAIT_INTERVAL_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted while waiting for UI Realm callback", e);
+      }
     }
-    throw lastError;
+    throw new AssertionError("Timed out waiting for UI Realm callback", lastError);
   }
 
 }

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,7 +42,6 @@ import com.microsoft.copilot.eclipse.ui.preferences.ByokPreferencePage;
 class ByokServiceTests {
 
   private static final long WAIT_TIMEOUT_MS = 5000;
-  private static final long WAIT_INTERVAL_MS = 25;
   private static final String OLLAMA_ENDPOINT = "http://localhost:11434";
   private static final String OLLAMA_PROVIDER = ByokModelProvider.OLLAMA.getDisplayName();
 
@@ -73,8 +73,8 @@ class ByokServiceTests {
 
     assertThrows(CompletionException.class, () -> byokService.configureOllama(OLLAMA_ENDPOINT).join());
 
-    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(argThat(
-      providerUrls -> OLLAMA_ENDPOINT.equals(providerUrls.get(OLLAMA_PROVIDER)))));
+    verify(preferencePage, timeout(WAIT_TIMEOUT_MS)).updateProviderUrlsDisplay(argThat(
+        providerUrls -> OLLAMA_ENDPOINT.equals(providerUrls.get(OLLAMA_PROVIDER))));
   }
 
   @Test
@@ -88,7 +88,8 @@ class ByokServiceTests {
 
     byokService.loadProviderUrls().join();
 
-    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(Map.of(OLLAMA_PROVIDER, OLLAMA_ENDPOINT)));
+    verify(preferencePage, timeout(WAIT_TIMEOUT_MS))
+        .updateProviderUrlsDisplay(Map.of(OLLAMA_PROVIDER, OLLAMA_ENDPOINT));
   }
 
   @Test
@@ -128,7 +129,7 @@ class ByokServiceTests {
 
     byokService.deleteOllamaConfig().join();
 
-    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(argThat(Map::isEmpty)));
+    verify(preferencePage, timeout(WAIT_TIMEOUT_MS)).updateProviderUrlsDisplay(argThat(Map::isEmpty));
   }
 
   private void configureRefreshResponses(List<ByokModel> discoveredModels) {
@@ -148,26 +149,6 @@ class ByokServiceTests {
     ByokStatusResponse response = new ByokStatusResponse();
     response.setSuccess(true);
     return CompletableFuture.completedFuture(response);
-  }
-
-  private static void waitUntil(Runnable verification) {
-    long timeout = System.currentTimeMillis() + WAIT_TIMEOUT_MS;
-    AssertionError lastError = null;
-    while (System.currentTimeMillis() < timeout) {
-      try {
-        verification.run();
-        return;
-      } catch (AssertionError e) {
-        lastError = e;
-      }
-      try {
-        Thread.sleep(WAIT_INTERVAL_MS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new AssertionError("Interrupted while waiting for UI Realm callback", e);
-      }
-    }
-    throw new AssertionError("Timed out waiting for UI Realm callback", lastError);
   }
 
 }

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.eclipse.swt.widgets.Display;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -71,8 +72,8 @@ class ByokServiceTests {
 
     assertThrows(CompletionException.class, () -> byokService.configureOllama(OLLAMA_ENDPOINT).join());
 
-    verify(preferencePage).updateProviderUrlsDisplay(argThat(
-        providerUrls -> OLLAMA_ENDPOINT.equals(providerUrls.get(OLLAMA_PROVIDER))));
+    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(argThat(
+      providerUrls -> OLLAMA_ENDPOINT.equals(providerUrls.get(OLLAMA_PROVIDER)))));
   }
 
   @Test
@@ -86,7 +87,7 @@ class ByokServiceTests {
 
     byokService.loadProviderUrls().join();
 
-    verify(preferencePage).updateProviderUrlsDisplay(Map.of(OLLAMA_PROVIDER, OLLAMA_ENDPOINT));
+    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(Map.of(OLLAMA_PROVIDER, OLLAMA_ENDPOINT)));
   }
 
   @Test
@@ -126,7 +127,7 @@ class ByokServiceTests {
 
     byokService.deleteOllamaConfig().join();
 
-    verify(preferencePage).updateProviderUrlsDisplay(argThat(Map::isEmpty));
+    waitUntil(() -> verify(preferencePage).updateProviderUrlsDisplay(argThat(Map::isEmpty)));
   }
 
   private void configureRefreshResponses(List<ByokModel> discoveredModels) {
@@ -147,4 +148,22 @@ class ByokServiceTests {
     response.setSuccess(true);
     return CompletableFuture.completedFuture(response);
   }
+
+  private static void waitUntil(Runnable verification) {
+    long timeout = System.currentTimeMillis() + 5000;
+    AssertionError lastError = null;
+    while (System.currentTimeMillis() < timeout) {
+      Display.getDefault().syncExec(() -> {
+        // Allow queued UI Realm callbacks to run before checking the mock.
+      });
+      try {
+        verification.run();
+        return;
+      } catch (AssertionError e) {
+        lastError = e;
+      }
+    }
+    throw lastError;
+  }
+
 }

--- a/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
+++ b/com.microsoft.copilot.eclipse.ui.test/src/com/microsoft/copilot/eclipse/ui/chat/services/ByokServiceTests.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.eclipse.swt.widgets.Display;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,9 +154,6 @@ class ByokServiceTests {
     long timeout = System.currentTimeMillis() + WAIT_TIMEOUT_MS;
     AssertionError lastError = null;
     while (System.currentTimeMillis() < timeout) {
-      Display.getDefault().syncExec(() -> {
-        // Allow queued UI Realm callbacks to run before checking the mock.
-      });
       try {
         verification.run();
         return;


### PR DESCRIPTION
## Fix test failure

The test verified `updateProviderUrlsDisplay()` immediately after
`configureOllama().join()`.

`join()` waits for the service future, but not the `ISideEffect` callback queued
on the SWT UI Realm. It passed in isolation but raced in the full CI suite.

Evidence:

```text
Wanted but not invoked:
preferencePage.updateProviderUrlsDisplay(...)

Actually, there were zero interactions with this mock.

Tests run: 459, Failures: 1
```

This is a follow up PR of #387 , fix #93