### PR TITLE
fix: prevent test processes from hanging CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    # Without an explicit limit a hung test JVM keeps the job alive for the 6 hour default and the
+    # logs are never published, which makes such hangs impossible to diagnose.
+    timeout-minutes: 45
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/lsp/LsStreamConnectionProviderTests.java
+++ b/com.microsoft.copilot.eclipse.core.test/src/com/microsoft/copilot/eclipse/core/lsp/LsStreamConnectionProviderTests.java
@@ -5,8 +5,10 @@ package com.microsoft.copilot.eclipse.core.lsp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -18,6 +20,7 @@ class LsStreamConnectionProviderTests {
 
   private static final String LEGACY_WORKSPACE_CONTEXT_PREFERENCE = "workspaceContextEnabled";
   private static final String UI_PREFERENCE_NODE = "com.microsoft.copilot.eclipse.ui";
+  private static final long TERMINATION_GRACE_MS = 2000L;
 
   @Test
   void testInitializationOptions() {
@@ -52,11 +55,61 @@ class LsStreamConnectionProviderTests {
 
   @Test
   void testStartLanguageServer() throws IOException {
-    LsStreamConnectionProvider provider = new LsStreamConnectionProvider();
+    TestableLsStreamConnectionProvider provider = new TestableLsStreamConnectionProvider();
+    Process process = null;
     try {
       provider.start();
+      process = provider.process();
+      assertNotNull(process, "starting the provider must create a language server process");
     } finally {
       provider.stop();
+      forceTerminate(process);
+    }
+
+    assertFalse(process.isAlive(), "the language server must not outlive the test");
+  }
+
+  /**
+   * Makes sure the language server is really gone before the test JVM exits.
+   *
+   * <p>LSP4E's {@code stop()} only asks the process to terminate and returns without waiting, and on
+   * Unix that request can be ignored. A surviving server still holds the stderr file descriptor it
+   * inherited from this JVM; inside a Tycho test fork that descriptor is Maven's pipe, so the
+   * Maven-side stream pump waits for an EOF that never arrives and the build hangs long after the
+   * tests have passed. Killing the process here keeps that failure mode out of CI without changing
+   * how the plugin manages language servers at runtime.
+   *
+   * @param process the language server process, or {@code null} if none was created
+   */
+  private static void forceTerminate(Process process) {
+    if (process == null) {
+      return;
+    }
+    process.destroy();
+    if (awaitExit(process)) {
+      return;
+    }
+    process.descendants().forEach(ProcessHandle::destroyForcibly);
+    process.destroyForcibly();
+    // destroyForcibly() only delivers the signal; without waiting, isAlive() can still be true.
+    awaitExit(process);
+  }
+
+  private static boolean awaitExit(Process process) {
+    try {
+      return process.waitFor(TERMINATION_GRACE_MS, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  /**
+   * Exposes the language server process so the test can assert on the real operating system process.
+   */
+  private static final class TestableLsStreamConnectionProvider extends LsStreamConnectionProvider {
+    Process process() {
+      return getProcess();
     }
   }
 }

--- a/com.microsoft.copilot.eclipse.swtbot.test/pom.xml
+++ b/com.microsoft.copilot.eclipse.swtbot.test/pom.xml
@@ -15,6 +15,12 @@
 		<checkstyle.skip>true</checkstyle.skip>
 		<!-- Default to empty; the osx profile below overrides to -XstartOnFirstThread. -->
 		<swtbot.platformArgLine></swtbot.platformArgLine>
+		<!-- This module owns no tests of its own: ProbeRunner exists only to execute the JSON
+		     script named by -Dprobe.script. Without a script it can do nothing, and its @BeforeClass
+		     Assume only fires once Tycho has already provisioned and launched a workbench - which
+		     starts a language server that then outlives the fork. Skip the whole execution instead,
+		     and let the swtbot-probe profile below switch it back on when a script is supplied. -->
+		<swtbot.skipTests>true</swtbot.skipTests>
 	</properties>
 
 	<profiles>
@@ -28,6 +34,19 @@
 			<properties>
 				<!-- SWT on macOS must be started on the main thread. -->
 				<swtbot.platformArgLine>-XstartOnFirstThread</swtbot.platformArgLine>
+			</properties>
+		</profile>
+		<profile>
+			<!-- Activated by -Dprobe.script=<path> on the command line. Profile activation only
+			     considers user properties, so the empty POM default above never triggers it. -->
+			<id>swtbot-probe</id>
+			<activation>
+				<property>
+					<name>probe.script</name>
+				</property>
+			</activation>
+			<properties>
+				<swtbot.skipTests>false</swtbot.skipTests>
 			</properties>
 		</profile>
 	</profiles>
@@ -59,6 +78,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<skipTests>${swtbot.skipTests}</skipTests>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
 					<includes>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,9 @@
 		<base.name>GitHub Copilot</base.name>
 		<tycho-version>4.0.13</tycho-version>
 		<checkstyle-version>3.6.0</checkstyle-version>
+		<!-- Kill a forked test JVM that stops making progress instead of letting it stall the build
+		     indefinitely; tycho-surefire reads this as forkedProcessTimeoutInSeconds. -->
+		<surefire.timeout>900</surefire.timeout>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## Summary

M2/3 (bottom) of the CI-hang stack. M1's exception-deadlock fix and M3's macOS shell-reader fix follow as separate layers. Because this intermediate PR intentionally excludes those fixes, CI may still hang until the full stack is applied.

This four-file layer:

- caps CI jobs at 45 minutes in `.github/workflows/ci.yml`
- caps inactive forked test JVMs at 900 seconds in the root `pom.xml`
- skips no-op SWTBot workbench launches unless `-Dprobe.script` is supplied
- makes the language-server test expose, stop, forcibly terminate if necessary, await, and assert exit of its spawned process

## Validation

- `./mvnw checkstyle:check` passes
- `./mvnw test` passes across all 19 modules, including the SWTBot no-op path
- `./mvnw clean verify` reaches compilation but packaging is blocked by the checkout's pre-existing missing `com.microsoft.copilot.eclipse.core/copilot-agent/dist/` input
- the four-file diff exactly matches the corresponding snapshot hunks from `01cf6650bf537bf3eb5c44f442b44ecbdd7353e3`