### PR TITLE
test: avoid starting CLS for Jobs image checks

### DIFF
--- a/com.microsoft.copilot.eclipse.ui.jobs.test/META-INF/MANIFEST.MF
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/META-INF/MANIFEST.MF
@@ -5,7 +5,9 @@ Bundle-SymbolicName: com.microsoft.copilot.eclipse.ui.jobs.test;singleton:=true
 Bundle-Version: 0.20.0.qualifier
 Bundle-Vendor: GitHub Copilot
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Fragment-Host: com.microsoft.copilot.eclipse.ui.jobs
 Automatic-Module-Name: com.microsoft.copilot.eclipse.ui.jobs.test
 Require-Bundle: junit-jupiter-api;bundle-version="5.10.1",
- junit-jupiter-params;bundle-version="5.10.1"
+ junit-jupiter-params;bundle-version="5.10.1",
+ org.eclipse.core.runtime;bundle-version="[3.30.0,4.0.0)",
+ com.microsoft.copilot.eclipse.ui.jobs;bundle-version="0.20.0"
+Import-Package: org.osgi.framework;version="[1.10.0,2.0.0)"

--- a/com.microsoft.copilot.eclipse.ui.jobs.test/build.properties
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/build.properties
@@ -1,6 +1,4 @@
 source.. = src
 output.. = target/classes
 bin.includes = META-INF/,\
-               .,\
-               fragment.xml
-
+               .

--- a/com.microsoft.copilot.eclipse.ui.jobs.test/fragment.xml
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/fragment.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-   
-</plugin>

--- a/com.microsoft.copilot.eclipse.ui.jobs.test/pom.xml
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/pom.xml
@@ -45,8 +45,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<useUIHarness>true</useUIHarness>
-					<useUIThread>false</useUIThread>
+					<useUIHarness>false</useUIHarness>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/com.microsoft.copilot.eclipse.ui.jobs.test/src/com/microsoft/copilot/eclipse/ui/jobs/CopilotJobsImagesTest.java
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/src/com/microsoft/copilot/eclipse/ui/jobs/CopilotJobsImagesTest.java
@@ -3,39 +3,41 @@
 
 package com.microsoft.copilot.eclipse.ui.jobs;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.stream.Stream;
 
+import org.eclipse.core.runtime.Platform;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.osgi.framework.Bundle;
 
 /**
- * Verifies that every public constant in {@link CopilotJobsImages} refers to a bundle resource
- * that actually exists on the classpath.
- *
- * <p>New constants are discovered automatically via reflection; no separate list needs to be
- * maintained.
+ * Verifies that every public image path in the Jobs bundle refers to an existing resource without
+ * activating the bundle.
  */
 class CopilotJobsImagesTest {
 
+  private static final String JOBS_BUNDLE_ID = "com.microsoft.copilot.eclipse.ui.jobs";
+
   static Stream<Arguments> iconPaths() {
-    return Stream.of(CopilotJobsImages.class.getDeclaredFields())
-        .filter(f -> f.getName().startsWith("IMG_"))
-        .map(f -> {
-          try {
-            return Arguments.of(f.getName(), f.get(null));
-          } catch (IllegalAccessException e) {
-            throw new IllegalStateException("Cannot read constant: " + f.getName(), e);
-          }
-        });
+    return Stream.of(
+        Arguments.of("IMG_REPO", "icons/repo.png"),
+        Arguments.of("IMG_INFORMATION", "icons/information.png"),
+        Arguments.of("IMG_STATUS_LOADING", "icons/status/loading.png"),
+        Arguments.of("IMG_STATUS_COMPLETE", "icons/status/complete.png"));
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("iconPaths")
   void testIconFileExists(String fieldName, String path) {
-    assertNotNull(CopilotJobsImages.class.getResource("/" + path),
+    Bundle jobsBundle = Platform.getBundle(JOBS_BUNDLE_ID);
+    assertNotNull(jobsBundle, "Jobs bundle not found");
+    assertNotNull(jobsBundle.getEntry(path),
         "Bundle resource not found for constant " + fieldName + ": " + path);
+    assertNotEquals(Bundle.ACTIVE, jobsBundle.getState(),
+        "Checking image resources must not activate the Jobs bundle");
   }
 }

--- a/com.microsoft.copilot.eclipse.ui.jobs.test/src/com/microsoft/copilot/eclipse/ui/jobs/CopilotJobsImagesTest.java
+++ b/com.microsoft.copilot.eclipse.ui.jobs.test/src/com/microsoft/copilot/eclipse/ui/jobs/CopilotJobsImagesTest.java
@@ -15,11 +15,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.osgi.framework.Bundle;
 
 /**
- * Verifies that every public image path in the Jobs bundle refers to an existing resource without
- * activating the bundle.
+ * Verifies that the curated public image paths from {@code CopilotJobsImages} refer to existing
+ * resources without activating the Jobs bundle.
+ *
+ * <p>The paths are duplicated here because loading {@code CopilotJobsImages} for reflection would
+ * activate its bundle and start the Copilot language server. Keep this list in sync with its public
+ * {@code IMG_*} constants.
  */
 class CopilotJobsImagesTest {
 
+  private static final String CORE_BUNDLE_ID = "com.microsoft.copilot.eclipse.core";
   private static final String JOBS_BUNDLE_ID = "com.microsoft.copilot.eclipse.ui.jobs";
 
   static Stream<Arguments> iconPaths() {
@@ -34,10 +39,20 @@ class CopilotJobsImagesTest {
   @MethodSource("iconPaths")
   void testIconFileExists(String fieldName, String path) {
     Bundle jobsBundle = Platform.getBundle(JOBS_BUNDLE_ID);
+    Bundle coreBundle = Platform.getBundle(CORE_BUNDLE_ID);
     assertNotNull(jobsBundle, "Jobs bundle not found");
+    assertNotNull(coreBundle, "Core bundle not found");
+    assertBundleNotActive(jobsBundle, "Jobs");
+    assertBundleNotActive(coreBundle, "Core");
     assertNotNull(jobsBundle.getEntry(path),
         "Bundle resource not found for constant " + fieldName + ": " + path);
-    assertNotEquals(Bundle.ACTIVE, jobsBundle.getState(),
-        "Checking image resources must not activate the Jobs bundle");
+    assertBundleNotActive(jobsBundle, "Jobs");
+    assertBundleNotActive(coreBundle, "Core");
+  }
+
+  private static void assertBundleNotActive(Bundle bundle, String name) {
+    // Tycho lazy-starts dependencies, leaving them in STARTING without invoking their activators.
+    assertNotEquals(Bundle.ACTIVE, bundle.getState(),
+        "Checking image resources must not activate the " + name + " bundle");
   }
 }


### PR DESCRIPTION
## Summary

- convert the Jobs image test fragment into an independent test bundle
- run the image resource checks with Tycho's headless test harness
- verify resource access does not activate the Jobs bundle, preventing Core and CLS startup

## Validation

- `./mvnw checkstyle:check`
- `./mvnw test`
- `./mvnw clean verify -Dtycho.testArgLine=-Dnet.bytebuddy.experimental=true`