### PR TITLE
fix - rendering of the what's new page for 0.21 is broken on webkit

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/intro/whatsnew/WHATISNEW.md
+++ b/com.microsoft.copilot.eclipse.ui/intro/whatsnew/WHATISNEW.md
@@ -3,7 +3,7 @@
 ### Use Ollama Models with BYOK
 You can now connect Ollama as a custom Bring Your Own Key (BYOK) model provider and use locally hosted models in Copilot Chat.
 
-<img src="0.21.0/ollama.png" alt="Ollama" width="600">
+<img src="0.21.0/ollama.png" alt="Ollama" width="600"/>
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/copilot-for-eclipse/issues/406