### PR TITLE
Refresh conversation templates dynamically on workspace project changes

### DIFF
--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
@@ -84,7 +84,7 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
       ResourcesPlugin.getWorkspace().addResourceChangeListener(this.resourceChangeListener,
           IResourceChangeEvent.POST_CHANGE);
     } catch (IllegalStateException e) {
-      // Workspace may not be available in standalone headless unit test environments
+      CopilotCore.LOGGER.info("Workspace not available; skipping resource change listener registration.");
     }
     syncCommands(this.authStatusManager.getCopilotStatus());
   }
@@ -93,13 +93,24 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
     if (delta == null) {
       return false;
     }
-    // If the delta is at the root level, check each child
+    if (delta.getResource() instanceof IProject) {
+      int kind = delta.getKind();
+      int flags = delta.getFlags();
+      if (kind == IResourceDelta.ADDED || kind == IResourceDelta.REMOVED) {
+        return true;
+      }
+      return (flags & (IResourceDelta.OPEN
+          | IResourceDelta.DESCRIPTION
+          | IResourceDelta.MOVED_FROM
+          | IResourceDelta.MOVED_TO
+          | IResourceDelta.REPLACED)) != 0;
+    }
     for (IResourceDelta child : delta.getAffectedChildren()) {
-      if (child.getResource() instanceof IProject) {
+      if (hasProjectChanges(child)) {
         return true;
       }
     }
-    return delta.getResource() instanceof IProject;
+    return false;
   }
 
   private void fetchAsync() {
@@ -250,7 +261,7 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
       try {
         ResourcesPlugin.getWorkspace().removeResourceChangeListener(this.resourceChangeListener);
       } catch (IllegalStateException e) {
-        // Workspace may not be available during shutdown
+        CopilotCore.LOGGER.info("Workspace not available; skipping resource change listener unregistration.");
       }
     }
   }

--- a/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
+++ b/com.microsoft.copilot.eclipse.ui/src/com/microsoft/copilot/eclipse/ui/chat/services/ChatCompletionService.java
@@ -10,12 +10,16 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.service.event.EventHandler;
@@ -31,6 +35,7 @@ import com.microsoft.copilot.eclipse.core.lsp.protocol.ConversationTemplate;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotScope;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.CopilotStatusResult;
 import com.microsoft.copilot.eclipse.core.lsp.protocol.TemplateSource;
+import com.microsoft.copilot.eclipse.core.utils.WorkspaceUtils;
 import com.microsoft.copilot.eclipse.ui.utils.PreferencesUtils;
 
 /**
@@ -49,6 +54,7 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
   private AuthStatusManager authStatusManager;
   private IEventBroker eventBroker;
   private EventHandler customPromptsChangedHandler;
+  private IResourceChangeListener resourceChangeListener;
 
   /**
    * Constructor for the SlashCommandService.
@@ -69,7 +75,31 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
       this.eventBroker.subscribe(CopilotEventConstants.TOPIC_CHAT_DID_CHANGE_CUSTOMIZATION_FILES,
           customPromptsChangedHandler);
     }
+    this.resourceChangeListener = event -> {
+      if (event.getType() == IResourceChangeEvent.POST_CHANGE && hasProjectChanges(event.getDelta())) {
+        fetchAsync();
+      }
+    };
+    try {
+      ResourcesPlugin.getWorkspace().addResourceChangeListener(this.resourceChangeListener,
+          IResourceChangeEvent.POST_CHANGE);
+    } catch (IllegalStateException e) {
+      // Workspace may not be available in standalone headless unit test environments
+    }
     syncCommands(this.authStatusManager.getCopilotStatus());
+  }
+
+  private boolean hasProjectChanges(IResourceDelta delta) {
+    if (delta == null) {
+      return false;
+    }
+    // If the delta is at the root level, check each child
+    for (IResourceDelta child : delta.getAffectedChildren()) {
+      if (child.getResource() instanceof IProject) {
+        return true;
+      }
+    }
+    return delta.getResource() instanceof IProject;
   }
 
   private void fetchAsync() {
@@ -103,7 +133,7 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
     // Pass workspace folders so the language server returns workspace-specific
     // prompt files (.prompt.md) and skills (SKILL.md) alongside built-in templates.
     try {
-      List<WorkspaceFolder> workspaceFolders = LSPEclipseUtils.getWorkspaceFolders();
+      List<WorkspaceFolder> workspaceFolders = WorkspaceUtils.listWorkspaceFolders();
       ConversationTemplate[] rawTemplates = this.lsConnection.listConversationTemplates(workspaceFolders).get();
       if (monitor.isCanceled()) {
         return;
@@ -215,6 +245,13 @@ public class ChatCompletionService implements CopilotAuthStatusListener {
     this.authStatusManager.removeCopilotAuthStatusListener(this);
     if (this.eventBroker != null && this.customPromptsChangedHandler != null) {
       this.eventBroker.unsubscribe(this.customPromptsChangedHandler);
+    }
+    if (this.resourceChangeListener != null) {
+      try {
+        ResourcesPlugin.getWorkspace().removeResourceChangeListener(this.resourceChangeListener);
+      } catch (IllegalStateException e) {
+        // Workspace may not be available during shutdown
+      }
     }
   }
 }


### PR DESCRIPTION
Currently, when Eclipse starts with an empty workspace (or when projects are imported, opened, closed, or deleted during a session), conversation templates, including slash commands (/), custom prompts, and skills, do not update until Eclipse is completely restarted.

This change adds tracking so conversation templates refresh automatically upon workspace changes. 

### Root Cause
1. `ChatCompletionService` used `LSPEclipseUtils.getWorkspaceFolders()`, which holds a stale startup snapshot from LSP4E.
2. `ChatCompletionService` had no `IResourceChangeListener` for workspace project changes.

### Changes
- Replaced `LSPEclipseUtils.getWorkspaceFolders()` with `WorkspaceUtils.listWorkspaceFolders()`.
- Added an `IResourceChangeListener` in `ChatCompletionService` to refresh conversation templates on `IProject` changes (`POST_CHANGE`).
- Unregistered the listener in `dispose()`.

### Testing
1. Started Eclipse with an empty workspace.
2. Imported a project
3. Verified my skills appeared in Chat's `/` completion list without restarting.


Note: There is also an upstream language server issue where `conversation/templates` skips global skills when `workspaceFolders` is empty; this fix ensures that as soon as a project is opened, templates refresh immediately.  For reference that issue is here: https://github.com/github/copilot-language-server-release/issues/51